### PR TITLE
Add patient-flags slot and add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## Requirements
+
+- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
+- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
+- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).
+
+
+## Summary
+
+<!--
+Required.
+Please describe what problems your PR addresses.
+-->
+
+
+## Screenshots
+
+*None.*
+<!--
+Optional.
+If possible, please insert any screenshots/videos of your changes here.
+Don't forget to remove the *None.* above if you do fill this section.
+-->
+
+
+## Related Issue
+
+*None.*
+<!--
+Required if applicable.
+If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
+Don't forget to remove the *None.* above if you do fill this section.
+-->
+
+
+## Other
+
+*None.*
+<!--
+Optional.
+Anything else that isn't covered by one of the sections above.
+Don't forget to remove the *None.* above if you do fill this section.
+-->

--- a/packages/esm-patient-flags-app/src/index.ts
+++ b/packages/esm-patient-flags-app/src/index.ts
@@ -22,7 +22,7 @@ function setupOpenMRS() {
     extensions: [
       {
         name: 'patient-flag',
-        slot: 'patient-banner-tags-slot',
+        slot: 'patient-flags-slot',
         load: getAsyncLifecycle(() => import('./patient-flags/patient-flags.component'), options),
         online: true,
         offline: false,

--- a/packages/esm-patient-flags-app/src/patient-flags/patient-flags.component.tsx
+++ b/packages/esm-patient-flags-app/src/patient-flags/patient-flags.component.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { InlineLoading, Tag } from 'carbon-components-react';
+import { Tag } from 'carbon-components-react';
 import { useTranslation } from 'react-i18next';
 import { usePatientFlags } from '../hooks/usePatientFlags';
+import styles from './patient-flags.scss';
 
 interface PatientFlagsProps {
   patientUuid: string;
@@ -16,13 +17,13 @@ const PatientFlags: React.FC<PatientFlagsProps> = ({ patientUuid }) => {
   }
 
   return (
-    <>
+    <div className={styles.flagContainer}>
       {patientFlags.map((patientFlag) => (
         <Tag key={patientFlag} type="magenta">
           {patientFlag}
         </Tag>
       ))}
-    </>
+    </div>
   );
 };
 

--- a/packages/esm-patient-flags-app/src/patient-flags/patient-flags.scss
+++ b/packages/esm-patient-flags-app/src/patient-flags/patient-flags.scss
@@ -1,0 +1,6 @@
+@import '~@openmrs/esm-styleguide/src/vars';
+@import '~carbon-components/src/globals/scss/vars';
+
+.flagContainer {
+    margin: $spacing-05;
+}


### PR DESCRIPTION
### What does this PR do?

- Add pull_request_template for this module.
- Add `patient-flags-slot` to display patient flags.
- Add styles for patient-flags component

### Screenshot

![Screenshot from 2022-08-04 11-32-39](https://user-images.githubusercontent.com/28008754/182801987-eafa1138-a728-4434-98de-63ff54696e6f.png)
