### PR TITLE
(fix) Fix: Correctly launch enrollment forms in edit or discontinuation mode

### DIFF
--- a/packages/esm-care-panel-app/src/program-enrollment/program-enrollment.component.test.tsx
+++ b/packages/esm-care-panel-app/src/program-enrollment/program-enrollment.component.test.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ProgramEnrollment, { ProgramEnrollmentProps } from './program-enrollment.component';
+import { showNotification } from '@openmrs/esm-framework';
+
+const mockLaunchWorkspace = jest.fn();
+const mockShowNotification = jest.fn();
+
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework'),
+  showNotification: jest.fn(),
+}));
 
 describe('ProgramEnrollment Component', () => {
   const mockProps: ProgramEnrollmentProps = {
@@ -21,7 +30,7 @@ describe('ProgramEnrollment Component', () => {
       },
     ],
     formEntrySub: jest.fn(),
-    launchPatientWorkspace: jest.fn(),
+    launchPatientWorkspace: mockLaunchWorkspace,
   };
 
   it('displays active program enrollment details correctly', () => {
@@ -68,5 +77,55 @@ describe('ProgramEnrollment Component', () => {
     expect(screen.getByText(/Stage 2/i)).toBeInTheDocument();
     expect(screen.getByText(/Entry Point/i)).toBeInTheDocument();
     expect(screen.getByText(/IPD/i)).toBeInTheDocument();
+  });
+
+  test('should show notification error when there is no encounter when launching forms', () => {
+    render(<ProgramEnrollment {...mockProps} />);
+
+    const editButton = screen.getByText(/Edit/i);
+    const deleteButton = screen.getByText(/Discontinue/i);
+
+    expect(editButton).toBeInTheDocument();
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+    expect(showNotification).toHaveBeenCalledWith({
+      title: 'Edit enrollment',
+      kind: 'error',
+      description:
+        'The enrollment form does not have an encounter associated with it, Please contact your system administrator to add an encounter to the enrollment',
+    });
+  });
+
+  test("should launch patient workspace when clicking on 'Edit' button", () => {
+    const updatedMockProps = {
+      ...mockProps,
+      data: [
+        {
+          ...mockProps.data[0],
+          data: [
+            {
+              ...mockProps.data[0].data[0],
+              enrollmentFormUuid: 'encounter-123',
+              enrollmentFormName: 'some form name',
+              enrollmentEncounterUuid: 'some-encounter-uuid',
+              discontinuationFormUuid: 'discontinuation-123',
+              discontinuationFormName: 'some form name',
+            },
+          ],
+        },
+      ],
+    };
+    render(<ProgramEnrollment {...updatedMockProps} />);
+
+    // Trigger the edit button
+    const editButton = screen.getByText(/Edit/i);
+
+    fireEvent.click(editButton);
+    expect(mockLaunchWorkspace).toHaveBeenCalled();
+    expect(mockLaunchWorkspace).toHaveBeenCalledWith('patient-form-entry-workspace', {
+      formInfo: { encounterUuid: 'some-encounter-uuid', formUuid: 'encounter-123' },
+      workspaceTitle: 'some form name',
+    });
   });
 });

--- a/packages/esm-care-panel-app/src/program-enrollment/program-enrollment.component.tsx
+++ b/packages/esm-care-panel-app/src/program-enrollment/program-enrollment.component.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Tile, Button, ButtonSet } from '@carbon/react';
 import styles from './program-enrollment.scss';
 import { Edit, TrashCan, Add } from '@carbon/react/icons';
-import { useLayoutType, useVisit } from '@openmrs/esm-framework';
+import { showNotification, useLayoutType } from '@openmrs/esm-framework';
 import isNull from 'lodash-es/isNull';
 import { ProgramType } from '../types';
 export interface ProgramEnrollmentProps {
@@ -14,25 +14,27 @@ export interface ProgramEnrollmentProps {
   launchPatientWorkspace: Function;
 }
 const ProgramEnrollment: React.FC<ProgramEnrollmentProps> = ({
-  patientUuid,
   programName,
   data,
-  formEntrySub,
+
   launchPatientWorkspace,
 }) => {
   const { t } = useTranslation();
   const isTablet = useLayoutType() == 'tablet';
-  const { currentVisit } = useVisit(patientUuid);
   const handleOpenWorkspace = (formUuid, formName, encounterUuid) => {
-    const mutateForm = () => {};
-    formEntrySub.next({ formUuid, encounterUuid });
-    launchPatientWorkspace('patient-form-entry-workspace', {
-      workspaceTitle: formName,
-      mutateForm,
-      formUuid,
-      encounterUuid,
-      visit: currentVisit,
-    });
+    !encounterUuid
+      ? showNotification({
+          title: t('editEnrollment', 'Edit enrollment'),
+          description: t(
+            'editEnrollmentMessage',
+            'The enrollment form does not have an encounter associated with it, Please contact your system administrator to add an encounter to the enrollment',
+          ),
+          kind: 'error',
+        })
+      : launchPatientWorkspace('patient-form-entry-workspace', {
+          workspaceTitle: formName,
+          formInfo: { formUuid, encounterUuid: encounterUuid ?? '' },
+        });
   };
   if (isNull(data)) {
     return;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Fixes a bug related to launching enrollment forms in edit or discontinuation mode.
- Adds a validation check to display an error message when an `encounterUuid` is missing during enrollment editing.

**Details**:
While addressing the issue with enrollment forms not launching correctly in edit or discontinuation mode, I noticed that there was no error handling for scenarios where the `encounterUuid` was missing during the editing of enrollments. To enhance the user experience and prevent potential errors, I've implemented a check to display an informative error message in such cases.



## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
