### PR TITLE
(fix) rowData in print preview should default to empty array

### DIFF
--- a/packages/esm-billing-app/src/invoice/printable-invoice/printable-invoice.component.tsx
+++ b/packages/esm-billing-app/src/invoice/printable-invoice/printable-invoice.component.tsx
@@ -35,15 +35,16 @@ const PrintableInvoice: React.FC<PrintableInvoiceProps> = ({ bill, patient, isLo
     { header: 'Total', key: 'total' },
   ];
 
-  const rowData = bill?.lineItems?.map((item, index) => {
-    return {
-      id: `${item.uuid}`,
-      billItem: item.item,
-      quantity: item.quantity,
-      price: item.price,
-      total: item.price * item.quantity,
-    };
-  });
+  const rowData =
+    bill?.lineItems?.map((item, index) => {
+      return {
+        id: `${item.uuid}`,
+        billItem: item.item,
+        quantity: item.quantity,
+        price: item.price,
+        total: item.price * item.quantity,
+      };
+    }) ?? [];
 
   const invoiceTotal = {
     'Total Amount': bill?.totalAmount,
@@ -76,7 +77,7 @@ const PrintableInvoice: React.FC<PrintableInvoiceProps> = ({ bill, patient, isLo
           showHeader={false}
           showToolbar={false}
           zebra
-          columnCount={headerData?.length}
+          columnCount={headerData?.length ?? 0}
           size={responsiveSize}
         />
       </div>
@@ -84,7 +85,7 @@ const PrintableInvoice: React.FC<PrintableInvoiceProps> = ({ bill, patient, isLo
   }
   return (
     <div className={styles.container}>
-      <PrintableInvoiceHeader patientDetails={patientDetails} />
+      {/* <PrintableInvoiceHeader patientDetails={patientDetails} /> */}
       <div className={styles.printableInvoiceContainer}>
         <div className={styles.detailsContainer}>
           {Object.entries(invoiceDetails).map(([key, val]) => (


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR fixes an error on print component to prevent `undefined` error on the empty array


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
