### PR TITLE
(fix) Fix bottom border for datatable filter empty state

### DIFF
--- a/packages/esm-billing-app/src/bills-table/bills-table.scss
+++ b/packages/esm-billing-app/src/bills-table/bills-table.scss
@@ -14,11 +14,14 @@
 .billListContainer {
   background-color: $ui-02;
   border: 1px solid $ui-03;
-  border-bottom: none;
   width: 100%;
   margin: 0 auto;
   max-width: 95vw;
   padding-bottom: 0;
+
+  :has(.filterEmptyState) {
+    border-bottom: none;
+  }
 }
 
 .headerContainer {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR restores a bottom border to the bill list data table's empty state that gets shown when the user filters the table content and there are no matching results to show.

## Screenshots

![CleanShot 2023-12-11 at 12  18 32@2x](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/62d67894-876c-4ed1-870e-4ed022673f59)


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
