### PR TITLE
(feat) Add search functionality to the line items table

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hookform/resolvers": "^3.1.1",
     "classnames": "^2.3.2",
+    "fuzzy": "^0.1.3",
     "react-hook-form": "^7.45.1",
     "zod": "^3.21.4"
   },

--- a/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
+++ b/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
@@ -92,7 +92,7 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
   if (bills?.length > 0) {
     return (
       <div className={styles.billHistoryContainer}>
-        <DataTable isSortable rows={rowData} headers={headerData} size={responsiveSize} useZebraStyles={true}>
+        <DataTable isSortable rows={rowData} headers={headerData} size={responsiveSize} useZebraStyles>
           {({
             rows,
             headers,

--- a/packages/esm-billing-app/src/billing.resource.ts
+++ b/packages/esm-billing-app/src/billing.resource.ts
@@ -5,6 +5,7 @@ import isEmpty from 'lodash-es/isEmpty';
 
 export const useBills = (patientUuid?: string) => {
   const url = `/ws/rest/v1/cashier/bill?v=full`;
+
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<PatientInvoice> } }>(
     url,
     openmrsFetch,
@@ -52,9 +53,13 @@ export const useBills = (patientUuid?: string) => {
 
 export const useBill = (billUuid: string) => {
   const url = `/ws/rest/v1/cashier/bill/${billUuid}`;
-  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: PatientInvoice }>(url, openmrsFetch, {
-    errorRetryCount: 2,
-  });
+  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: PatientInvoice }>(
+    billUuid ? url : null,
+    openmrsFetch,
+    {
+      errorRetryCount: 2,
+    },
+  );
 
   const mapBillProperties = (bill: PatientInvoice): MappedBill => {
     // create base object

--- a/packages/esm-billing-app/src/helpers/functions.ts
+++ b/packages/esm-billing-app/src/helpers/functions.ts
@@ -37,7 +37,9 @@ export const convertToCurrency = (amountToConvert: number) => {
     currency: 'KES',
     minimumFractionDigits: 2,
   });
+
   let formattedAmount = formatter.format(Math.abs(amountToConvert));
+
   if (amountToConvert < 0) {
     formattedAmount = `(${formattedAmount})`;
   }

--- a/packages/esm-billing-app/src/invoice/invoice-table.component.tsx
+++ b/packages/esm-billing-app/src/invoice/invoice-table.component.tsx
@@ -1,38 +1,56 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import fuzzy from 'fuzzy';
 import {
   DataTable,
+  DataTableSkeleton,
+  Layer,
   Table,
+  TableBody,
+  TableCell,
   TableContainer,
   TableHead,
-  TableRow,
-  TableBody,
   TableHeader,
-  TableCell,
-  DataTableSkeleton,
+  TableRow,
+  TableToolbar,
+  TableToolbarContent,
+  TableToolbarSearch,
+  Tile,
 } from '@carbon/react';
 import { Information } from '@carbon/react/icons';
-import { isDesktop, useLayoutType } from '@openmrs/esm-framework';
+import { isDesktop, useDebounce, useLayoutType } from '@openmrs/esm-framework';
 import { useBill } from '../billing.resource';
 import styles from './invoice-table.scss';
-import { useTranslation } from 'react-i18next';
 
 type InvoiceTableProps = {
   billUuid: string;
 };
 
 const InvoiceTable: React.FC<InvoiceTableProps> = ({ billUuid }) => {
-  const layout = useLayoutType();
   const { t } = useTranslation();
+  const layout = useLayoutType();
   const responsiveSize = isDesktop(layout) ? 'sm' : 'lg';
-  const tableTitle = t('lineItems', 'Line items');
-  const tableDescription = (
-    <p className={styles.tableDescription}>
-      <span>{t('lineItemsToBeBilled', 'Line items to be billed')}</span>
-      <Information />
-    </p>
-  );
   const { bill, isLoading } = useBill(billUuid);
-  const headerData = [
+  const { lineItems } = bill;
+  const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm);
+
+  const filteredLineItems = useMemo(() => {
+    if (!debouncedSearchTerm) {
+      return lineItems;
+    }
+
+    return debouncedSearchTerm
+      ? fuzzy
+          .filter(debouncedSearchTerm, lineItems, {
+            extract: (lineItem) => `${lineItem.item}`,
+          })
+          .sort((r1, r2) => r1.score - r2.score)
+          .map((result) => result.original)
+      : lineItems;
+  }, [debouncedSearchTerm, lineItems]);
+
+  const tableHeaders = [
     { header: 'No', key: 'no' },
     { header: 'Bill item', key: 'billItem' },
     { header: 'Bill code', key: 'billCode' },
@@ -42,29 +60,32 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({ billUuid }) => {
     { header: 'Total', key: 'total' },
   ];
 
-  const rowData =
-    bill?.lineItems?.map((item, index) => {
-      return {
-        no: `${index + 1}`,
-        id: `${item.uuid}`,
-        billItem: item.item,
-        billCode: bill.receiptNumber,
-        status: bill.status,
-        quantity: item.quantity,
-        price: item.price,
-        total: item.price * item.quantity,
-      };
-    }) ?? [];
+  const tableRows = useMemo(
+    () =>
+      filteredLineItems?.map((item, index) => {
+        return {
+          no: `${index + 1}`,
+          id: `${item.uuid}`,
+          billItem: item.item,
+          billCode: bill.receiptNumber,
+          status: bill.status,
+          quantity: item.quantity,
+          price: item.price,
+          total: item.price * item.quantity,
+        };
+      }) ?? [],
+    [bill.receiptNumber, bill.status, filteredLineItems],
+  );
 
   if (isLoading) {
     return (
       <div className={styles.loaderContainer}>
         <DataTableSkeleton
+          columnCount={tableHeaders?.length}
           showHeader={false}
           showToolbar={false}
-          zebra
-          columnCount={headerData?.length}
           size={responsiveSize}
+          zebra
         />
       </div>
     );
@@ -72,10 +93,30 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({ billUuid }) => {
 
   return (
     <div className={styles.invoiceContainer}>
-      <DataTable isSortable rows={rowData} headers={headerData} size={responsiveSize} useZebraStyles={true}>
+      <DataTable headers={tableHeaders} isSortable rows={tableRows} size={responsiveSize} useZebraStyles>
         {({ rows, headers, getRowProps, getTableProps, getToolbarProps }) => (
-          <TableContainer title={tableTitle} description={tableDescription}>
-            <Table {...getTableProps()} aria-label="Invoice line items">
+          <TableContainer
+            description={
+              <p className={styles.tableDescription}>
+                <span>{t('lineItemsToBeBilled', 'Line items to be billed')}</span>
+                <Information />
+              </p>
+            }
+            title={t('lineItems', 'Line items')}>
+            <div className={styles.toolbarWrapper}>
+              <TableToolbar {...getToolbarProps()} className={styles.tableToolbar} size={responsiveSize}>
+                <TableToolbarContent className={styles.headerContainer}>
+                  <TableToolbarSearch
+                    className={styles.searchbox}
+                    expanded
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
+                    placeholder={t('searchThisTable', 'Search this table')}
+                    size={responsiveSize}
+                  />
+                </TableToolbarContent>
+              </TableToolbar>
+            </div>
+            <Table {...getTableProps()} aria-label="Invoice line items" className={styles.table}>
               <TableHead>
                 <TableRow>
                   {headers.map((header) => (
@@ -100,6 +141,18 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({ billUuid }) => {
           </TableContainer>
         )}
       </DataTable>
+      {filteredLineItems?.length === 0 && (
+        <div className={styles.filterEmptyState}>
+          <Layer>
+            <Tile className={styles.filterEmptyStateTile}>
+              <p className={styles.filterEmptyStateContent}>
+                {t('noMatchingItemsToDisplay', 'No matching items to display')}
+              </p>
+              <p className={styles.filterEmptyStateHelper}>{t('checkFilters', 'Check the filters above')}</p>
+            </Tile>
+          </Layer>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/esm-billing-app/src/invoice/invoice-table.scss
+++ b/packages/esm-billing-app/src/invoice/invoice-table.scss
@@ -3,8 +3,49 @@
 @use '@carbon/type';
 @import '~@openmrs/esm-styleguide/src/vars';
 
+.filterEmptyState {
+  align-items: center;
+  background-color: white;
+  display: flex;
+  justify-content: center;
+  padding: layout.$spacing-09 !important;
+  text-align: center;
+}
+
+.filterEmptyStateTile {
+  margin: auto;
+}
+
+.filterEmptyStateContent {
+  @include type.type-style('heading-compact-02');
+  color: $text-02;
+  margin-bottom: 0.5rem;
+}
+
+.filterEmptyStateHelper {
+  @include type.type-style('body-compact-01');
+  color: $text-02;
+}
+
+.headerContainer {
+  background-color: colors.$gray-10;
+}
+
 .invoiceContainer {
-  margin: 0 layout.$spacing-05 layout.$spacing-05 layout.$spacing-05;
+  margin: layout.$spacing-09 layout.$spacing-05 0;
+  border: 1px solid $ui-03;
+}
+
+.searchbox {
+  input:focus {
+    outline: 2px solid colors.$orange-40 !important;
+  }
+}
+
+.table {
+  td {
+    border-bottom: none !important;
+  }
 }
 
 .tableDescription {
@@ -23,5 +64,28 @@
 
   & > span {
     @include type.type-style('body-01');
+  }
+}
+
+.tableToolbar {
+  width: 20%;
+  min-width: 12.5rem;
+}
+
+.toolbarWrapper {
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+}
+
+:global(.omrs-breakpoint-lt-desktop) {
+  .toolbarWrapper {
+    height: layout.$spacing-09;
+  }
+}
+
+:global(.omrs-breakpoint-gt-tablet) {
+  .toolbarWrapper {
+    height: layout.$spacing-07;
   }
 }

--- a/packages/esm-billing-app/src/invoice/invoice.component.tsx
+++ b/packages/esm-billing-app/src/invoice/invoice.component.tsx
@@ -1,4 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
+import { useReactToPrint } from 'react-to-print';
+import { useTranslation } from 'react-i18next';
 import { Button, InlineLoading } from '@carbon/react';
 import { Printer } from '@carbon/react/icons';
 import { ErrorState } from '@openmrs/esm-patient-common-lib';
@@ -6,8 +9,6 @@ import { ExtensionSlot, usePatient } from '@openmrs/esm-framework';
 import { convertToCurrency } from '../helpers';
 import { useBill } from '../billing.resource';
 import { useParams } from 'react-router-dom';
-import { useReactToPrint } from 'react-to-print';
-import { useTranslation } from 'react-i18next';
 import InvoiceTable from './invoice-table.component';
 import Payments from './payments/payments.component';
 import PrintableInvoice from './printable-invoice/printable-invoice.component';
@@ -70,7 +71,11 @@ const Invoice: React.FC<InvoiceProps> = () => {
   }
 
   if (error) {
-    return <ErrorState headerTitle={t('invoiceError', 'Invoice error')} error={error} />;
+    return (
+      <div className={styles.errorContainer}>
+        <ErrorState headerTitle={t('invoiceError', 'Invoice error')} error={error} />
+      </div>
+    );
   }
 
   return (
@@ -93,12 +98,14 @@ const Invoice: React.FC<InvoiceProps> = () => {
         </div>
       </div>
 
-      <div>
-        <InvoiceTable billUuid={bill?.uuid} />
-        {bill && <Payments bill={bill} />}
-      </div>
+      <InvoiceTable billUuid={bill?.uuid} />
+      {bill && <Payments bill={bill} />}
 
-      <div ref={contentToPrintRef} className={isPrinting === true ? '' : styles.printContainer}>
+      <div
+        className={classNames({
+          [styles.printContainer]: isPrinting !== true,
+        })}
+        ref={contentToPrintRef}>
         <PrintableInvoice bill={bill} patient={patient} isLoading={isLoading} />
       </div>
     </div>

--- a/packages/esm-billing-app/src/invoice/invoice.scss
+++ b/packages/esm-billing-app/src/invoice/invoice.scss
@@ -7,6 +7,10 @@
   height: calc(100vh - 3rem);
 }
 
+.errorContainer {
+  margin: layout.$spacing-05;
+}
+
 .loader {
   display: flex;
   min-height: layout.$spacing-09;

--- a/packages/esm-billing-app/src/invoice/payments/invoice-breakdown/invoice-breakdown.component.tsx
+++ b/packages/esm-billing-app/src/invoice/payments/invoice-breakdown/invoice-breakdown.component.tsx
@@ -9,7 +9,7 @@ type InvoiceBreakDownProps = {
 export const InvoiceBreakDown: React.FC<InvoiceBreakDownProps> = ({ label, value }) => {
   return (
     <div className={styles.invoiceBreakdown}>
-      <span className={styles.label}>{label} : </span>
+      <span className={styles.label}>{label}: </span>
       <span className={styles.value}>{value}</span>
     </div>
   );

--- a/packages/esm-billing-app/src/invoice/payments/invoice-breakdown/invoice-breakdown.scss
+++ b/packages/esm-billing-app/src/invoice/payments/invoice-breakdown/invoice-breakdown.scss
@@ -6,19 +6,18 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   align-items: flex-end;
+  margin: layout.$spacing-02 0;
 }
 
 .label {
-  @include type.type-style('heading-02');
-  color: colors.$gray-70;
-  margin: layout.$spacing-01;
+  @include type.type-style('heading-03');
+  color: colors.$gray-100;
   text-align: end;
 }
 
 .value {
-  @include type.type-style('heading-02');
-  margin-top: layout.$spacing-04;
+  @extend .label;
+  font-weight: bold;
+  margin-left: layout.$spacing-03;
   text-align: start;
-  margin-left: layout.$spacing-02;
-  color: colors.$black;
 }

--- a/packages/esm-billing-app/src/invoice/payments/payment-form/payment-form.component.tsx
+++ b/packages/esm-billing-app/src/invoice/payments/payment-form/payment-form.component.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback } from 'react';
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { TrashCan, Add } from '@carbon/react/icons';
-import { Button, Dropdown, TextInput, NumberInputSkeleton } from '@carbon/react';
-import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
-import styles from './payment-form.scss';
-import { usePaymentModes } from '../payment.resource';
+import { Button, Dropdown, NumberInputSkeleton, TextInput } from '@carbon/react';
 import { ErrorState } from '@openmrs/esm-patient-common-lib';
 import { PaymentFormValue } from '../payments.component';
+import { usePaymentModes } from '../payment.resource';
+import styles from './payment-form.scss';
 
 type PaymentFormProps = { disablePayment: boolean };
 
@@ -35,7 +35,7 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ disablePayment }) => {
   }
 
   return (
-    <div>
+    <div className={styles.container}>
       {fields.map((field, index) => (
         <div key={field.id} className={styles.paymentMethodContainer}>
           <Controller
@@ -59,25 +59,30 @@ const PaymentForm: React.FC<PaymentFormProps> = ({ disablePayment }) => {
             name={`payment.${index}.amount`}
             render={({ field }) => (
               <TextInput
+                {...field}
                 invalid={!!errors?.payment?.[index]?.amount}
                 invalidText={errors?.payment?.[index]?.amount?.message}
-                light
-                {...field}
-                type="number"
                 labelText={t('amount', 'Amount')}
+                light
+                type="number"
               />
             )}
           />
-
           <Controller
             name={`payment.${index}.referenceCode`}
             control={control}
             render={({ field }) => (
-              <TextInput light {...field} type="text" labelText={t('referenceNumber', 'Ref number')} />
+              <TextInput
+                {...field}
+                labelText={t('referenceNumber', 'Ref number')}
+                light
+                placeholder={t('enterReferenceNumber', 'Enter ref. number')}
+                type="text"
+              />
             )}
           />
           <div className={styles.removeButtonContainer}>
-            <TrashCan onClick={handleRemovePaymentMode} className={styles.removeButton} size={24} />
+            <TrashCan onClick={handleRemovePaymentMode} className={styles.removeButton} size={20} />
           </div>
         </div>
       ))}

--- a/packages/esm-billing-app/src/invoice/payments/payment-form/payment-form.scss
+++ b/packages/esm-billing-app/src/invoice/payments/payment-form/payment-form.scss
@@ -2,6 +2,10 @@
 @use '@carbon/layout';
 @use '@carbon/type';
 
+.container {
+  margin: 1rem;
+}
+
 .paymentContainer {
   margin: layout.$layout-01;
   padding: layout.$layout-01;
@@ -15,7 +19,7 @@
 
 .paymentMethodContainer {
   display: grid;
-  grid-template-columns: repeat(4, minmax(100px, 1fr));
+  grid-template-columns: repeat(4, minmax(auto, 1fr));
   align-items: flex-start;
   column-gap: 1rem;
   margin: 0.625rem 0;
@@ -37,14 +41,14 @@
   margin: layout.$spacing-04;
   min-height: layout.$spacing-09;
 }
-.removeButtonContainer{
+
+.removeButtonContainer {
   display: flex;
-  align-items: center;
-  height: layout.$spacing-09;
   align-self: center;
   cursor: pointer;
+  margin-left: layout.$spacing-07;
 }
+
 .removeButton {
-  align-self: center;
   color: colors.$red-60;
 }

--- a/packages/esm-billing-app/src/invoice/payments/payments.component.tsx
+++ b/packages/esm-billing-app/src/invoice/payments/payments.component.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@carbon/react';
 import { navigate, showSnackbar } from '@openmrs/esm-framework';
-import { useTranslation } from 'react-i18next';
 import { CardHeader } from '@openmrs/esm-patient-common-lib';
-import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { type MappedBill } from '../../types';
 import { convertToCurrency } from '../../helpers';
-import { InvoiceBreakDown } from './invoice-breakdown/invoice-breakdown.component';
-import { MappedBill } from '../../types';
-import PaymentHistory from './payment-history/payment-history.component';
-import styles from './payments.scss';
-import PaymentForm from './payment-form/payment-form.component';
 import { createPaymentPayload } from './utils';
 import { processBillPayment } from '../../billing.resource';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+import { InvoiceBreakDown } from './invoice-breakdown/invoice-breakdown.component';
+import PaymentHistory from './payment-history/payment-history.component';
+import PaymentForm from './payment-form/payment-form.component';
+import styles from './payments.scss';
 
 const paymentSchema = z.object({
   method: z.string().refine((value) => !!value, 'Payment method is required'),
@@ -23,6 +23,7 @@ const paymentSchema = z.object({
   ]),
   referenceCode: z.union([z.number(), z.string()]).optional(),
 });
+
 const paymentFormSchema = z.object({ payment: z.array(paymentSchema) });
 
 type PaymentProps = { bill: MappedBill };
@@ -81,6 +82,7 @@ const Payments: React.FC<PaymentProps> = ({ bill }) => {
             <PaymentForm disablePayment={amountDue <= 0} />
           </div>
         </div>
+        <div className={styles.divider} />
         <div className={styles.paymentTotals}>
           <InvoiceBreakDown label={t('totalAmount', 'Total Amount')} value={convertToCurrency(bill.totalAmount)} />
           <InvoiceBreakDown
@@ -89,17 +91,13 @@ const Payments: React.FC<PaymentProps> = ({ bill }) => {
           />
           <InvoiceBreakDown label={t('discount', 'Discount')} value={'--'} />
           <InvoiceBreakDown label={t('amountDue', 'Amount due')} value={convertToCurrency(amountDue ?? 0)} />
-          <div>
-            <div className={styles.processPayments}>
-              <Button onClick={handleNavigateToBillingDashboard} kind="secondary">
-                {t('discard', 'Discard')}
-              </Button>
-              <Button
-                onClick={() => handleProcessPayment()}
-                disabled={!formValues?.length || !methods.formState.isValid}>
-                {t('processPayment', 'Process Payment')}
-              </Button>
-            </div>
+          <div className={styles.processPayments}>
+            <Button onClick={handleNavigateToBillingDashboard} kind="secondary">
+              {t('discard', 'Discard')}
+            </Button>
+            <Button onClick={() => handleProcessPayment()} disabled={!formValues?.length || !methods.formState.isValid}>
+              {t('processPayment', 'Process Payment')}
+            </Button>
           </div>
         </div>
       </div>

--- a/packages/esm-billing-app/src/invoice/payments/payments.scss
+++ b/packages/esm-billing-app/src/invoice/payments/payments.scss
@@ -6,11 +6,17 @@
   display: flex;
 }
 
+.divider {
+  background: colors.$gray-20;
+  height: 12rem;
+  margin: 2rem;
+  width: 1px;
+}
+
 .paymentContainer {
-  margin: layout.$layout-01;
+  margin: layout.$layout-01 0;
   padding: layout.$layout-01;
   width: 70%;
-  border-right: 1px solid colors.$cool-gray-40;
 }
 
 .paymentButtons {
@@ -26,7 +32,8 @@
 }
 
 .paymentTotals {
-  margin-top: layout.$spacing-01;
+  margin: layout.$spacing-05 0;
+  padding: layout.$spacing-07 layout.$spacing-05;
 }
 
 .processPayments {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,6 +2479,7 @@ __metadata:
     eslint-config-prettier: "npm:^8.2.0"
     eslint-config-ts-react-important-stuff: "npm:^3.0.0"
     eslint-plugin-prettier: "npm:^3.3.1"
+    fuzzy: "npm:^0.1.3"
     husky: "npm:^8.0.1"
     i18next: "npm:^19.7.0"
     i18next-parser: "npm:^5.4.0"
@@ -10561,6 +10562,13 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: 0ddfd3ed1066a55984aaecebf5419fbd9344a5c38dd120ffb0739fac4496758dcf371297440528b115e4367fc46e3abc86a2cc0ff44612181b175ae967a11a05
+  languageName: node
+  linkType: hard
+
+"fuzzy@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "fuzzy@npm:0.1.3"
+  checksum: 3cf399457f3f9832af5d72bdbf354b287d977fca6bd800fb457579a9ccf8d8faa297f70ab7fada0147591e022d817532072ab07f69490b84f5dda96051e8c3ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

I've added the ability to search through the line items table by bill item (it should be possible to add the status as a searchable property, though I've found that the value of the status property for a bill line item differs from the value I get from the backend. I don't know if this is owing to some custom functionality on the frontend that I'm not aware of @donaldkibet). 

I've also added an empty state that gets displayed when there are no matching search results. Additionally, I've tweaked some aspects of the invoice details UI and the payments table to align them more closely with the designs.

## Screenshots

> Before

![CleanShot 2023-12-12 at 11  55 48@2x](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/2f8c3c01-4f6b-489f-8684-2a5695b7dd53)

> After

https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/55a414bd-0235-4ff0-a944-298345336e43

## Related Issue

*None.*

## Other

*None.*
