### PR TITLE
(fix) Line items table header fixes

### DIFF
--- a/packages/esm-billing-app/src/invoice/invoice-table.component.tsx
+++ b/packages/esm-billing-app/src/invoice/invoice-table.component.tsx
@@ -98,8 +98,8 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({ billUuid }) => {
           <TableContainer
             description={
               <p className={styles.tableDescription}>
-                <span>{t('lineItemsToBeBilled', 'Line items to be billed')}</span>
-                <Information />
+                <span>{t('itemsToBeBilled', 'Items to be billed')}</span>
+                <Information className={styles.infoIcon} />
               </p>
             }
             title={t('lineItems', 'Line items')}>

--- a/packages/esm-billing-app/src/invoice/invoice-table.scss
+++ b/packages/esm-billing-app/src/invoice/invoice-table.scss
@@ -89,3 +89,8 @@
     height: layout.$spacing-07;
   }
 }
+
+.infoIcon {
+  margin-top: layout.$spacing-01;
+  margin-left: layout.$spacing-02;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

I've fixed the following issues in the line items datatable:
- Change the table description content to match the designs
- Apply some margin to the info tooltip icon 

## Screenshots

> Before

![CleanShot 2023-12-14 at 2  27 28@2x](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/d7834803-db68-4f5e-8e95-ca6314a38a23)

> After

![CleanShot 2023-12-14 at 2  26 08@2x](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/ce45d757-5b0b-497e-bc9f-59240b1d2484)

## Related Issue

*None*

## Other

*None*