### PR TITLE
(feat) Remove info toolip from line items table header

### DIFF
--- a/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
+++ b/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
@@ -1,7 +1,5 @@
-import { ErrorState, isDesktop, useConfig, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useBills } from '../billing.resource';
 import {
   DataTableSkeleton,
   Layer,
@@ -19,9 +17,11 @@ import {
   TableExpandRow,
   TableExpandedRow,
 } from '@carbon/react';
-import styles from './bill-history.scss';
+import { ErrorState, isDesktop, useConfig, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { EmptyDataIllustration } from '@openmrs/esm-patient-common-lib';
+import { useBills } from '../billing.resource';
 import InvoiceTable from '../invoice/invoice-table.component';
+import styles from './bill-history.scss';
 
 interface BillHistoryProps {
   patientUuid: string;

--- a/packages/esm-billing-app/src/invoice/invoice-table.component.tsx
+++ b/packages/esm-billing-app/src/invoice/invoice-table.component.tsx
@@ -99,7 +99,6 @@ const InvoiceTable: React.FC<InvoiceTableProps> = ({ billUuid }) => {
             description={
               <p className={styles.tableDescription}>
                 <span>{t('itemsToBeBilled', 'Items to be billed')}</span>
-                <Information className={styles.infoIcon} />
               </p>
             }
             title={t('lineItems', 'Line items')}>

--- a/packages/esm-billing-app/src/invoice/invoice-table.scss
+++ b/packages/esm-billing-app/src/invoice/invoice-table.scss
@@ -89,8 +89,3 @@
     height: layout.$spacing-07;
   }
 }
-
-.infoIcon {
-  margin-top: layout.$spacing-01;
-  margin-left: layout.$spacing-02;
-}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

I've removed the info tooltip that sat next to the line items table header description. This is following guidance from Ted. The designs will be updated appropriately in future.

## Screenshots

![CleanShot 2023-12-15 at 11  07 28@2x](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/31e92cda-c72d-474d-b7dd-d7b1614304c8)

## Related Issue

*None.*

## Other

*None.*