### PR TITLE
(fix) Fix placement of background data fetching indicator

### DIFF
--- a/packages/esm-billing-app/src/bills-table/bills-table.component.tsx
+++ b/packages/esm-billing-app/src/bills-table/bills-table.component.tsx
@@ -260,28 +260,28 @@ function FilterableTableHeader({
         </div>
         <div className={styles.backgroundDataFetchingIndicator}>
           <span>{isValidating ? <InlineLoading /> : null}</span>
-          <div>
-            <Tag type="red" title={billPaymentStatus}>
-              {billPaymentStatus === '' ? 'ALL' : billPaymentStatus}
-            </Tag>
-            <OverflowMenu flipped renderIcon={Filter}>
-              <OverflowMenuItem
-                className={styles.menuitem}
-                onClick={() => handleSetBillPaymentStatus('')}
-                itemText={t('all', 'ALL')}
-              />
-              <OverflowMenuItem
-                className={styles.menuitem}
-                onClick={() => handleSetBillPaymentStatus('PAID')}
-                itemText={t('paid', 'PAID')}
-              />
-              <OverflowMenuItem
-                className={styles.menuitem}
-                onClick={() => handleSetBillPaymentStatus('PENDING')}
-                itemText={t('pending', 'PENDING')}
-              />
-            </OverflowMenu>
-          </div>
+        </div>
+        <div>
+          <Tag type="red" title={billPaymentStatus}>
+            {billPaymentStatus === '' ? 'ALL' : billPaymentStatus}
+          </Tag>
+          <OverflowMenu className={styles.menu} flipped renderIcon={Filter}>
+            <OverflowMenuItem
+              className={styles.menuitem}
+              onClick={() => handleSetBillPaymentStatus('')}
+              itemText={t('all', 'ALL')}
+            />
+            <OverflowMenuItem
+              className={styles.menuitem}
+              onClick={() => handleSetBillPaymentStatus('PAID')}
+              itemText={t('paid', 'PAID')}
+            />
+            <OverflowMenuItem
+              className={styles.menuitem}
+              onClick={() => handleSetBillPaymentStatus('PENDING')}
+              itemText={t('pending', 'PENDING')}
+            />
+          </OverflowMenu>
         </div>
       </div>
       <Search

--- a/packages/esm-billing-app/src/bills-table/bills-table.scss
+++ b/packages/esm-billing-app/src/bills-table/bills-table.scss
@@ -24,18 +24,21 @@
   }
 }
 
+.menu {
+  margin-left: layout.$spacing-03;
+}
+
 .headerContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: layout.$spacing-04 0 layout.$spacing-04 layout.$spacing-05;
+  padding: layout.$spacing-04 layout.$spacing-05;
   background-color: $ui-02;
 }
 
 .backgroundDataFetchingIndicator {
   align-items: center;
   display: flex;
-  flex: 1 1 0%;
   justify-content: space-between;
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Fixes the placement of the background data fetching indicator in the bill list table header.


## Screenshots

![CleanShot 2023-12-15 at 4  12 21@2x](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/fcf687e5-8cbe-46c6-87ab-2573873d2bb0)


## Related Issue

*None.*

## Other

*None.*