### PR TITLE
(feat) Update flags apperance and update unit test to `80`%

### DIFF
--- a/packages/esm-patient-flags-app/jest.config.js
+++ b/packages/esm-patient-flags-app/jest.config.js
@@ -1,3 +1,8 @@
 const rootConfig = require('../../jest.config.js');
 
-module.exports = rootConfig;
+const packageConfig = {
+  ...rootConfig,
+  collectCoverage: true,
+};
+
+module.exports = packageConfig;

--- a/packages/esm-patient-flags-app/src/clear-cache/clear-cache.component.test.tsx
+++ b/packages/esm-patient-flags-app/src/clear-cache/clear-cache.component.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
-import { useTranslation } from 'react-i18next';
+import { render, screen } from '@testing-library/react';
 import ClearCacheButton from './clear-cache.component';
-
+import userEvent from '@testing-library/user-event';
 // Mocking window.location.reload
 Object.defineProperty(window, 'location', {
   value: {
@@ -18,11 +17,11 @@ describe('ClearCacheButton', () => {
   });
 
   it('clears local and session storage and reloads the page when clicked', async () => {
-    const { container } = render(<ClearCacheButton />);
+    const user = userEvent.setup();
+    render(<ClearCacheButton />);
     const button = await screen.findByRole('button', { name: /Reload & Clear Cache/i });
     expect(button).toBeInTheDocument();
-    fireEvent.click(button);
-
+    await user.click(button);
     expect(localStorage.clear).toHaveBeenCalled();
     expect(sessionStorage.clear).toHaveBeenCalled();
     expect(window.location.reload).toHaveBeenCalled();

--- a/packages/esm-patient-flags-app/src/hooks/usePatientId.tsx
+++ b/packages/esm-patient-flags-app/src/hooks/usePatientId.tsx
@@ -1,12 +1,10 @@
 import { openmrsFetch } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 
-const usePatientId = (patientUuid: string) => {
+export const usePatientId = (patientUuid: string) => {
   const { isLoading, data, error } = useSWR<{ data: { results: { patientId: string; age: number } } }>(
     `/ws/rest/v1/kenyaemr/patient?patientUuid=${patientUuid}`,
     openmrsFetch,
   );
   return { patient: data?.data?.results, error, isLoading };
 };
-
-export default usePatientId;

--- a/packages/esm-patient-flags-app/src/kenyaemr-link/kenyaemr-chart-link.component.tsx
+++ b/packages/esm-patient-flags-app/src/kenyaemr-link/kenyaemr-chart-link.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '@carbon/react';
 import { Home } from '@carbon/react/icons';
 import { useTranslation } from 'react-i18next';
-import usePatientId from '../hooks/usePatientId';
+import { usePatientId } from '../hooks/usePatientId';
 import { navigate } from '@openmrs/esm-framework';
 
 const KenyaEMRChartLink = () => {

--- a/packages/esm-patient-flags-app/src/kenyaemr-link/kenyaemr-chart-link.test.tsx
+++ b/packages/esm-patient-flags-app/src/kenyaemr-link/kenyaemr-chart-link.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import KenyaEMRChartLink from './kenyaemr-chart-link.component';
+import { navigate } from '@openmrs/esm-framework';
+import userEvent from '@testing-library/user-event';
+import { usePatientId } from '../hooks/usePatientId';
+
+const mockNavigate = navigate as jest.MockedFunction<typeof navigate>;
+const mockUsePatientid = usePatientId as jest.MockedFunction<typeof usePatientId>;
+
+jest.mock('@openmrs/esm-framework', () => ({
+  navigate: jest.fn(),
+}));
+
+jest.mock('../hooks/usePatientId', () => {
+  const originalModule = jest.requireActual('../hooks/usePatientId');
+  return { ...originalModule, usePatientId: jest.fn() };
+});
+
+describe('KenyaEMRChartLink', () => {
+  test('renders KenyaEMRChartLink component', async () => {
+    const user = userEvent.setup();
+    mockUsePatientid.mockReturnValue({ isLoading: false, patient: { patientId: '1234', age: 20 }, error: null });
+    render(<KenyaEMRChartLink />);
+    const link = screen.getByRole('button', { name: /2.x Chart/i });
+    expect(link).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    await user.click(link);
+    expect(mockNavigate).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/openmrs/kenyaemr/chart/chartViewPatient.page?patientId=1234&' });
+  });
+});

--- a/packages/esm-patient-flags-app/src/patient-flags/patient-flags.component.tsx
+++ b/packages/esm-patient-flags-app/src/patient-flags/patient-flags.component.tsx
@@ -19,7 +19,7 @@ const PatientFlags: React.FC<PatientFlagsProps> = ({ patientUuid }) => {
   return (
     <div className={styles.flagContainer}>
       {patientFlags.map((patientFlag) => (
-        <Tag key={patientFlag} type="magenta">
+        <Tag className={styles.tag} key={patientFlag} type="magenta">
           {patientFlag}
         </Tag>
       ))}

--- a/packages/esm-patient-flags-app/src/patient-flags/patient-flags.scss
+++ b/packages/esm-patient-flags-app/src/patient-flags/patient-flags.scss
@@ -1,6 +1,13 @@
-@use '@carbon/styles/scss/spacing';
-@import '~@openmrs/esm-styleguide/src/vars';
+@use '@carbon/colors';
+@use '@carbon/layout';
 
 .flagContainer {
-  margin: spacing.$spacing-05;
+  margin: layout.$spacing-05;
+}
+
+.tag {
+  background-color: #ffff00; // not present in carbon colors
+  color: colors.$black;
+  padding: layout.$spacing-03;
+  cursor: pointer;
 }

--- a/packages/esm-patient-flags-app/src/patient-flags/patient-flags.test.tsx
+++ b/packages/esm-patient-flags-app/src/patient-flags/patient-flags.test.tsx
@@ -21,4 +21,10 @@ describe('<PatientFlags/>', () => {
     expect(screen.getByText(/^hiv$/i)).toBeInTheDocument();
     expect(screen.getByText(/^cancer$/i)).toBeInTheDocument();
   });
+
+  test("should display error message when there's an error", () => {
+    mockUsePatientFlags.mockReturnValue({ isLoading: false, patientFlags: [], error: 'some-error' });
+    render(<PatientFlags patientUuid="some-patient-uuid" />);
+    expect(screen.getByText(/Error loading patient flags/i)).toBeInTheDocument();
+  });
 });

--- a/packages/esm-patient-flags-app/src/root.component.tsx
+++ b/packages/esm-patient-flags-app/src/root.component.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
-
-const PatientSearchRootComponent: React.FC = () => {
-  return <BrowserRouter basename={`${window['getOpenmrsSpaBase']()}`}></BrowserRouter>;
-};
-
-export default PatientSearchRootComponent;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR makes changes to `esm-patient-flags` to do the following.
1. Remove unused file `root.component.tsx`
2. Update test to a coverage of `80`% 
3. Update the flags colors to be similar to whats on 2.x and requested in the UAT. cc Keziah, @palladiumkenya/qa
4. Use `userEvent` and replace `fireEvent` in test to simulate user interactions
## Screenshots

*None.*
![Screenshot from 2023-12-18 15-12-39](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/28008754/29bb6a39-2e9a-4544-8cb6-2cf664ec4fac)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
