### PR TITLE
(feat) Add patient-chart-clinical-views group link

### DIFF
--- a/packages/esm-patient-clinical-view-app/src/clinical-view-group/createDashboardGroup.tsx
+++ b/packages/esm-patient-clinical-view-app/src/clinical-view-group/createDashboardGroup.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { DashboardGroupExtension } from './dashboard-group.component';
+
+export const createDashboardGroup = ({
+  title,
+  slotName,
+  isExpanded,
+}: {
+  title: string;
+  slotName: string;
+  isExpanded?: boolean;
+}) => {
+  const DashboardGroup = ({ basePath }: { basePath: string }) => {
+    return <DashboardGroupExtension title={title} slotName={slotName} basePath={basePath} isExpanded={isExpanded} />;
+  };
+  return DashboardGroup;
+};

--- a/packages/esm-patient-clinical-view-app/src/clinical-view-group/dashboard-group.component.tsx
+++ b/packages/esm-patient-clinical-view-app/src/clinical-view-group/dashboard-group.component.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react';
+import { ExtensionSlot } from '@openmrs/esm-framework';
+import { Accordion, AccordionItem } from '@carbon/react';
+import { registerNavGroup } from '@openmrs/esm-patient-common-lib';
+import styles from './dashboard-group.scss';
+
+export interface DashboardGroupExtensionProps {
+  title: string;
+  slotName?: string;
+  basePath: string;
+  isExpanded?: boolean;
+}
+
+export const DashboardGroupExtension = ({ title, slotName, basePath, isExpanded }: DashboardGroupExtensionProps) => {
+  useEffect(() => {
+    registerNavGroup(slotName);
+  }, [slotName]);
+
+  return (
+    <div className={styles.accordionContainer}>
+      <Accordion>
+        <AccordionItem
+          className={styles.accordionItem}
+          open={isExpanded ?? true}
+          title={title}
+          style={{ borderBottom: 'none' }}>
+          <ExtensionSlot style={{ width: '100%', minWidth: '15rem' }} name={slotName ?? title} state={{ basePath }} />
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+};

--- a/packages/esm-patient-clinical-view-app/src/clinical-view-group/dashboard-group.scss
+++ b/packages/esm-patient-clinical-view-app/src/clinical-view-group/dashboard-group.scss
@@ -1,0 +1,13 @@
+@use '@carbon/layout';
+@use '@carbon/colors';
+@use '@carbon/type';
+
+.accordionContainer {
+  margin-top: layout.$spacing-05;
+}
+
+.accordionItem {
+  & > button {
+    margin-bottom: layout.$spacing-01;
+  }
+}

--- a/packages/esm-patient-clinical-view-app/src/clinical-view-group/dashboard-group.test.tsx
+++ b/packages/esm-patient-clinical-view-app/src/clinical-view-group/dashboard-group.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import * as openmrsEsmFramework from '@openmrs/esm-patient-common-lib';
+import { DashboardGroupExtension } from './dashboard-group.component';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@openmrs/esm-patient-common-lib', () => ({
+  registerNavGroup: jest.fn(),
+}));
+
+describe('DashboardGroupExtension', () => {
+  const defaultProps = {
+    title: 'Test Title',
+    slotName: 'test-slot',
+    basePath: '/base/path',
+    isExpanded: true,
+  };
+
+  test('renders with default props', async () => {
+    const user = userEvent.setup();
+    render(<DashboardGroupExtension {...defaultProps} />);
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    const accodionButton = screen.getByRole('button', { name: 'Test Title' });
+    expect(accodionButton).toHaveAttribute('aria-expanded', 'true');
+
+    // should collapse the accordion
+    await userEvent.click(accodionButton);
+    expect(accodionButton).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('calls registerNavGroup with slotName', () => {
+    render(<DashboardGroupExtension {...defaultProps} />);
+    expect(openmrsEsmFramework.registerNavGroup).toHaveBeenCalledWith('test-slot');
+  });
+});

--- a/packages/esm-patient-clinical-view-app/src/dashboard.meta.tsx
+++ b/packages/esm-patient-clinical-view-app/src/dashboard.meta.tsx
@@ -1,0 +1,14 @@
+export const ClinicalDashboardGroup = {
+  title: 'Clinical View',
+  slotName: 'patient-clinical-view-slot',
+  isExpanded: true,
+};
+
+export const mchDashboardMeta = {
+  slot: 'patient-chart-mch-dashboard-slot',
+  columns: 1,
+  title: 'MCH Dashboard',
+  path: 'mch-dashboard',
+  moduleName: '@kenyaemr/esm-patient-clinical-view-app',
+  config: {},
+};

--- a/packages/esm-patient-clinical-view-app/src/index.ts
+++ b/packages/esm-patient-clinical-view-app/src/index.ts
@@ -1,16 +1,20 @@
-import { defineConfigSchema, getAsyncLifecycle, getSyncLifecycle } from '@openmrs/esm-framework';
+import { defineConfigSchema, getSyncLifecycle } from '@openmrs/esm-framework';
 import { configSchema } from './config-schema';
 import { createDashboardLink, registerWorkspace } from '@openmrs/esm-patient-common-lib';
 import MaternalHealthList from './esm-mch-app/views/maternal-health/maternal-health.component';
-
+import './root.scss';
+import { createDashboardGroup } from './clinical-view-group/createDashboardGroup';
+import { ClinicalDashboardGroup, mchDashboardMeta } from './dashboard.meta';
 const moduleName = '@kenyaemr/esm-patient-clinical-view-app';
 
 const options = {
   featureName: 'patient-clinical-view-app',
   moduleName,
 };
-
+export const clinicalViewGroup = getSyncLifecycle(createDashboardGroup(ClinicalDashboardGroup), options);
+export const mchDashboardLink = getSyncLifecycle(createDashboardLink(mchDashboardMeta), options);
 export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
+
 export const mchClinicalView = getSyncLifecycle(MaternalHealthList, options);
 export function startupApp() {
   defineConfigSchema(moduleName, configSchema);

--- a/packages/esm-patient-clinical-view-app/src/routes.json
+++ b/packages/esm-patient-clinical-view-app/src/routes.json
@@ -7,11 +7,29 @@
   "extensions": [
     {
       "name": "mch-clinical-view",
-      "slot": "top-of-all-patient-dashboards-slot", 
+      "slot": "patient-chart-mch-dashboard-slot",
       "component": "mchClinicalView",
       "order": 0,
       "online": true,
       "offline": false
+    },
+    {
+      "name": "patient-clinical-view-group-link",
+      "slot": "patient-chart-dashboard-slot",
+      "component": "clinicalViewGroup"
+    },
+    {
+      "name": "mch-dashboard-link",
+      "component": "mchDashboardLink",
+      "slot": "patient-clinical-view-slot",
+      "order": 11,
+      "meta": {
+        "columns": 1,
+        "columnSpan": 1,
+        "slot": "patient-chart-mch-dashboard-slot",
+        "path": "mch-dashboard",
+        "layoutMode": "anchored"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR adds custom grouping for clinical views. I have also wired`MCH Dashboard` to the view.

``` json
   {
      "name": "mch-dashboard-link",
      "component": "mchDashboardLink",
      "slot": "patient-clinical-view-slot",
      "order": 11,
      "meta": {
        "columns": 1,
        "columnSpan": 1,
        "slot": "patient-chart-mch-dashboard-slot",
        "path": "mch-dashboard",
        "layoutMode": "anchored"
      }
    }
```

The above code attaches the `mch-dashboard-linkl` to our custom slot. The dashboard to be displayed is defined her

``` json
{
      "name": "mch-clinical-view",
      "slot": "patient-chart-mch-dashboard-slot",
      "component": "mchClinicalView",
      "order": 0,
      "online": true,
      "offline": false
}
```



## Screenshots
https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/28008754/635f401a-49c2-4473-a108-422ead2a99ae


## TODO
At the moment we need to define an expression to be evaluated to hide some dashboard based on some criteria. e.g `MCH Dashboard` should be hidden male clients and female client not enrolled to mch


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
