### PR TITLE
(feat) revert to origal flags styling

### DIFF
--- a/packages/esm-patient-flags-app/src/patient-flags/patient-flags.scss
+++ b/packages/esm-patient-flags-app/src/patient-flags/patient-flags.scss
@@ -6,8 +6,5 @@
 }
 
 .tag {
-  background-color: #ffff00; // not present in carbon colors
-  color: colors.$black;
-  padding: layout.$spacing-03;
   cursor: pointer;
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Revert back to original color theme for  flags


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
