### PR TITLE
(test) Add global test timeout to Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -47,4 +47,5 @@ module.exports = {
   testEnvironmentOptions: {
     url: 'http://localhost/',
   },
+  testTimeout: 15000,
 };

--- a/packages/esm-care-panel-app/src/patient-summary/patient-summary.component.tsx
+++ b/packages/esm-care-panel-app/src/patient-summary/patient-summary.component.tsx
@@ -1,12 +1,12 @@
 import React, { useRef, useState } from 'react';
-import styles from './patient-summary.scss';
 import { useTranslation } from 'react-i18next';
-import { formatDate, useLayoutType, useSession } from '@openmrs/esm-framework';
-import { StructuredListSkeleton, Button } from '@carbon/react';
-import { usePatientSummary } from '../hooks/usePatientSummary';
 import { Printer } from '@carbon/react/icons';
+import { StructuredListSkeleton, Button } from '@carbon/react';
 import { useReactToPrint } from 'react-to-print';
+import { formatDate, useLayoutType, useSession } from '@openmrs/esm-framework';
+import { usePatientSummary } from '../hooks/usePatientSummary';
 import PrintComponent from '../print-layout/print.component';
+import styles from './patient-summary.scss';
 
 interface PatientSummaryProps {
   patientUuid: string;
@@ -607,13 +607,13 @@ const PatientSummary: React.FC<PatientSummaryProps> = ({ patientUuid }) => {
             <div className={styles.content}>
               <p className={styles.label}>{t('viralLoadTrends', 'Viral load trends')}</p>
               {data?.allVlResults?.value?.length > 0
-                ? data?.allVlResults?.value?.map((vl) => {
+                ? data?.allVlResults?.value?.map((vl, index) => {
                     return (
-                      <>
+                      <div key={`vl-${index}`}>
                         <span className={styles.value}> {vl.vl} </span>
                         {vl?.vlDate === 'N/A' || vl?.vlDate === '' ? <span>None</span> : <span>{vl.vlDate}</span>}
                         <br />
-                      </>
+                      </div>
                     );
                   })
                 : '--'}
@@ -621,16 +621,16 @@ const PatientSummary: React.FC<PatientSummaryProps> = ({ patientUuid }) => {
             <div className={styles.content}>
               <p className={styles.label}>{t('cd4Trends', 'CD4 Trends')}</p>
               {data?.allCd4CountResults?.length > 0
-                ? data?.allCd4CountResults?.map((cd4) => {
+                ? data?.allCd4CountResults?.map((cd4, index) => {
                     return (
-                      <>
+                      <div key={`cd4Trend-${cd4}-${index}`}>
                         <span className={styles.value}> {cd4.cd4Count} </span>
                         <span className={styles.label}>
                           {' '}
                           {cd4.cd4CountDate ? formatDate(new Date(cd4.cd4CountDate)) : '--'}
                         </span>
                         <br />
-                      </>
+                      </div>
                     );
                   })
                 : '--'}

--- a/packages/esm-care-panel-app/src/program-summary/program-summary.test.tsx
+++ b/packages/esm-care-panel-app/src/program-summary/program-summary.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
-import ProgramSummary, { ProgramSummaryProps } from './program-summary.component';
+import { render, screen } from '@testing-library/react';
 import { mockProgram } from '../../../../__mocks__/program-summary.mock';
 import { formatDate } from '@openmrs/esm-framework';
+import ProgramSummary, { ProgramSummaryProps } from './program-summary.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
@@ -25,9 +25,7 @@ describe('ProgramSummary Component', () => {
   };
 
   it('displays HIV program details correctly', async () => {
-    await act(async () => {
-      render(<ProgramSummary {...mockProps} />);
-    });
+    render(<ProgramSummary {...mockProps} />);
 
     expect(screen.getByText('Current status')).toBeInTheDocument();
     expect(screen.getByText('Last viral load')).toBeInTheDocument();
@@ -51,9 +49,8 @@ describe('ProgramSummary Component', () => {
       ...mockProps,
       programName: 'TB',
     };
-    await act(async () => {
-      render(<ProgramSummary {...tbProps} />);
-    });
+
+    render(<ProgramSummary {...tbProps} />);
 
     expect(screen.getByText('Treatment number')).toBeInTheDocument();
     expect(screen.getByText(mockProgram.TB.tbTreatmentNumber)).toBeInTheDocument();
@@ -68,9 +65,8 @@ describe('ProgramSummary Component', () => {
       ...mockProps,
       programName: 'mchMother',
     };
-    await act(async () => {
-      render(<ProgramSummary {...mchMotherProps} />);
-    });
+
+    render(<ProgramSummary {...mchMotherProps} />);
 
     expect(screen.getByText('HIV status')).toBeInTheDocument();
     expect(screen.getByText(mockProgram.mchMother.hivStatus)).toBeInTheDocument();
@@ -85,9 +81,8 @@ describe('ProgramSummary Component', () => {
       ...mockProps,
       programName: 'mchChild',
     };
-    await act(async () => {
-      render(<ProgramSummary {...mchChildProps} />);
-    });
+
+    render(<ProgramSummary {...mchChildProps} />);
 
     expect(screen.getByText('HIV Status')).toBeInTheDocument();
     expect(screen.getByText(mockProgram.mchChild.hivStatus)).toBeInTheDocument();

--- a/packages/esm-patient-clinical-view-app/src/data-table/o-table.component.test.tsx
+++ b/packages/esm-patient-clinical-view-app/src/data-table/o-table.component.test.tsx
@@ -11,8 +11,6 @@ const testProps = {
   isExpandable: false,
 };
 
-jest.setTimeout(20000);
-
 jest.mock('@openmrs/esm-framework', () => ({
   ...jest.requireActual('@openmrs/esm-framework'),
   useLayoutType: jest.fn(() => 'small-desktop'),

--- a/packages/esm-patient-clinical-view-app/src/encounter-list/encounter-list.component.test.tsx
+++ b/packages/esm-patient-clinical-view-app/src/encounter-list/encounter-list.component.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { EncounterList } from './encounter-list.component';
 import {
   formConceptMap,
@@ -45,9 +45,7 @@ jest.mock('@openmrs/esm-framework', () => ({
 }));
 
 describe('EncounterList', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  afterEach(() => jest.clearAllMocks());
 
   test('should render loading datatable skeleton', async () => {
     // Mock SWRImmutable hook to return error state
@@ -72,9 +70,7 @@ describe('EncounterList', () => {
     }));
     const user = userEvent.setup();
 
-    await act(async () => {
-      render(<EncounterList {...testProps} />);
-    });
+    render(<EncounterList {...testProps} />);
 
     expect(screen.getByText('Test Date')).toBeInTheDocument();
     expect(screen.getByText('Test type')).toBeInTheDocument();
@@ -113,9 +109,9 @@ describe('EncounterList', () => {
       goTo: () => {},
       results: [],
     }));
-    await act(async () => {
-      render(<EncounterList {...testProps} />);
-    });
+
+    render(<EncounterList {...testProps} />);
+
     expect(screen.getByText(/There are no encounters to display/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR adds a global testTimeout property to the Jest configuration so that tests know to run within a 15000ms timeout. This should hopefully fix issues with tests timing out non-deterministically.

## Screenshots

*None*

## Related Issue

*None*

## Other

*None*