### PR TITLE
(fix) Fix date rendering in care panel summary

### DIFF
--- a/packages/esm-care-panel-app/src/hooks/usePatientSummary.ts
+++ b/packages/esm-care-panel-app/src/hooks/usePatientSummary.ts
@@ -1,6 +1,6 @@
 import { openmrsFetch } from '@openmrs/esm-framework';
-import useSWR from 'swr';
 import { PatientSummary } from '../types/index';
+import useSWR from 'swr';
 
 export const usePatientSummary = (patientUuid: string) => {
   const programSummaryUrl = `/ws/rest/v1/kenyaemr/patientSummary?patientUuid=${patientUuid}`;
@@ -8,7 +8,7 @@ export const usePatientSummary = (patientUuid: string) => {
 
   return {
     data: data?.data ? data?.data : null,
-    isError: error,
-    isLoading: isLoading,
+    error,
+    isLoading,
   };
 };

--- a/packages/esm-care-panel-app/src/patient-summary/patient-summary.component.test.tsx
+++ b/packages/esm-care-panel-app/src/patient-summary/patient-summary.component.test.tsx
@@ -34,7 +34,7 @@ describe('PatientSummary', () => {
   beforeEach(() => {
     mockedUsePatientSummary.mockReturnValue({
       data: null,
-      isError: false,
+      error: false,
       isLoading: true,
     });
   });
@@ -48,9 +48,17 @@ describe('PatientSummary', () => {
   });
 
   it('renders an error message when data retrieval fails', () => {
+    const mockError = {
+      message: 'You are not logged in',
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+      },
+    };
+
     mockedUsePatientSummary.mockReturnValue({
       data: null,
-      isError: true,
+      error: mockError,
       isLoading: false,
     });
 
@@ -62,7 +70,7 @@ describe('PatientSummary', () => {
   it('renders patient summary data when loaded', () => {
     mockedUsePatientSummary.mockReturnValue({
       data: mockPatient,
-      isError: false,
+      error: null,
       isLoading: false,
     });
 
@@ -92,7 +100,7 @@ describe('PatientSummary', () => {
 
     mockedUsePatientSummary.mockReturnValue({
       data: mockPatient,
-      isError: false,
+      error: null,
       isLoading: false,
     });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR fixes an issue with the care panel summary component where the component would fail to render owing to an issue with the date format of the `cd4CountDate` property in the API response. Specifically, this field is a `Date` with the format `DD/MM/YYYY` (which is different than the ISO strings we get back for other date fields). 

![CleanShot 2024-01-19 at 11  56 52@2x](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/dde9ffde-c5b4-41b1-849f-fed87de3cfaf)

The logic that handles rendering the field in the UI invokes the `new Date` constructor on the `cd4CountDate` which would fail silently:

![CleanShot 2024-01-19 at 11  57 21@2x](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/7588f7a8-0814-4c4e-82fb-0bfbdb5c93ad)

I've added special handling for dates of this format so that the date conversion using `formatDate` and the `new Date` constructor doesn't fail, causing the whole component to fail to render.

## Screenshots

> Before

![CleanShot 2024-01-19 at 11  59 15@2x](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/5e15a33d-0423-4871-bf7e-9f007bddfce0)

> After

![CleanShot 2024-01-19 at 12  00 02@2x](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/8509731/31dce4f3-c056-4afc-a1d9-ae79486a6618)

*None*

## Related Issue

*None*

## Other

*None*
