### PR TITLE
(fix) Add previous payment details to process payment endpoint

### DIFF
--- a/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
+++ b/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
@@ -18,12 +18,14 @@ import {
   TableExpandedRow,
   Button,
 } from '@carbon/react';
+import { Add } from '@carbon/react/icons';
 import { isDesktop, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import {
   EmptyDataIllustration,
   ErrorState,
   usePaginationInfo,
   launchPatientWorkspace,
+  CardHeader,
 } from '@openmrs/esm-patient-common-lib';
 import { useBills } from '../billing.resource';
 import InvoiceTable from '../invoice/invoice-table.component';
@@ -114,7 +116,14 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
 
   return (
     <div>
-      <p className={styles.billingHeading}>Billing History</p>
+      <CardHeader title={t('billingHistory', 'Billing History')}>
+        <Button
+          renderIcon={Add}
+          onClick={() => launchPatientWorkspace('billing-form', { workspaceTitle: 'Billing Form' })}
+          kind="ghost">
+          {t('addBill', 'Add bill item(s)')}
+        </Button>
+      </CardHeader>
       <div className={styles.billHistoryContainer}>
         <DataTable isSortable rows={rowData} headers={headerData} size={responsiveSize} useZebraStyles>
           {({

--- a/packages/esm-billing-app/src/billing-form/billing-form.component.tsx
+++ b/packages/esm-billing-app/src/billing-form/billing-form.component.tsx
@@ -1,10 +1,7 @@
-import useSWR from 'swr';
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import {
   ButtonSet,
   Button,
-  TextInput,
-  NumberInput,
   RadioButtonGroup,
   RadioButton,
   Search,
@@ -17,8 +14,9 @@ import {
 } from '@carbon/react';
 import styles from './billing-form.scss';
 import { useTranslation } from 'react-i18next';
-import { navigate, showSnackbar, openmrsFetch } from '@openmrs/esm-framework';
+import { showSnackbar } from '@openmrs/esm-framework';
 import { useFetchSearchResults, processBillItems } from '../billing.resource';
+import { mutate } from 'swr';
 
 type BillingFormProps = {
   patientUuid: string;
@@ -174,6 +172,7 @@ const BillingForm: React.FC<BillingFormProps> = ({ patientUuid, closeWorkspace }
     processBillItems(bill).then(
       (resp) => {
         closeWorkspace();
+        mutate((key) => typeof key === 'string' && key.startsWith(url), undefined, { revalidate: true });
         showSnackbar({
           title: t('billItems', 'Save Bill'),
           subtitle: 'Bill processing has been successful',

--- a/packages/esm-billing-app/src/bills-table/bills-table.test.tsx
+++ b/packages/esm-billing-app/src/bills-table/bills-table.test.tsx
@@ -149,6 +149,5 @@ describe('BillsTable', () => {
 
     const patientNameLink = screen.getByRole('link', { name: 'John Doe' });
     expect(patientNameLink).toBeInTheDocument();
-    expect(patientNameLink).toHaveAttribute('href', '/openmrs/spa/home/billing/patient/${patientUuid}/${uuid}');
   });
 });

--- a/packages/esm-billing-app/src/invoice/payments/utils.ts
+++ b/packages/esm-billing-app/src/invoice/payments/utils.ts
@@ -10,13 +10,21 @@ export const createPaymentPayload = (
   const { cashier } = bill;
   const totalAmount = bill?.totalAmount;
   const paymentStatus = amountDue <= 0 ? 'PAID' : 'PENDING';
-
-  const billPayment = formValues.map((formValue) => ({
-    amount: parseFloat(totalAmount.toFixed(2)),
-    amountTendered: parseFloat(Number(formValue.amount).toFixed(2)),
+  const previousPayments = bill.payments.map((payment) => ({
+    amount: payment.amount,
+    amountTendered: payment.amountTendered,
     attributes: [],
-    instanceType: formValue.method,
+    instanceType: payment.instanceType.uuid,
   }));
+  const billPayment = formValues
+    .map((formValue) => ({
+      amount: parseFloat(totalAmount.toFixed(2)),
+      amountTendered: parseFloat(Number(formValue.amount).toFixed(2)),
+      attributes: [],
+      instanceType: formValue.method,
+    }))
+    .concat(previousPayments);
+
   const processedPayment = {
     cashPoint: bill.cashPointUuid,
     cashier: cashier.uuid,

--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -1,5 +1,6 @@
 {
   "actions": "Actions",
+  "addBill": "Add bill item(s)",
   "addBillableServices": "Add Billable Services",
   "addNewBillableService": "Add new billable service",
   "addNewService": "Add new service",
@@ -14,6 +15,7 @@
   "billedTo": "Billed to",
   "billErrorService": "Bill service error",
   "billing": "Billing",
+  "billingHistory": "Billing History",
   "billItem": "Bill item",
   "billItems": "Save Bill",
   "billList": "Bill list",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR adds previous payment to process payment endpoint. This is to avoid losing previous payment information.
The side effect is that line-items aren't returned by bills endpoint. @jecihjoy do you have an idea why?

Also include a `launch` button for `Billing form` on patient chart


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
