### PR TITLE
(enhc) further improvements on outpatient clinical views

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "husky install",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx,css,scss}\" \"e2e/**/*.ts\"",
     "release": "lerna version --no-git-tag-version",
-    "start": "openmrs develop",
+    "start": "openmrs develop --sources packages/esm-patient-clinical-view-app --backend https://dev.kenyahmis.org --port 8090",
     "verify": "turbo run lint && turbo run typescript && turbo run test --color --concurrency=5"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "husky install",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx,css,scss}\" \"e2e/**/*.ts\"",
     "release": "lerna version --no-git-tag-version",
-    "start": "openmrs develop --sources packages/esm-patient-clinical-view-app --backend https://dev.kenyahmis.org --port 8090",
+    "start": "openmrs develop",
     "verify": "turbo run lint && turbo run typescript && turbo run test --color --concurrency=5"
   },
   "resolutions": {

--- a/packages/esm-patient-clinical-view-app/src/clinical-encounter/summary/out-patient-summary/patient-medical-history.component.tsx
+++ b/packages/esm-patient-clinical-view-app/src/clinical-encounter/summary/out-patient-summary/patient-medical-history.component.tsx
@@ -1,15 +1,27 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { formatDate, parseDate, useConfig } from '@openmrs/esm-framework';
+import { formatDate, useConfig } from '@openmrs/esm-framework';
 import { SURGICAL_HISTORY_UUID, ACCIDENT_TRAUMA_UUID, BLOOD_TRANSFUSION_UUID } from '../../../utils/constants';
 import { getObsFromEncounter } from '../../../ui/encounter-list/encounter-list-utils';
-import { EmptyState, launchPatientWorkspace, ErrorState } from '@openmrs/esm-patient-common-lib';
-import { OverflowMenu, OverflowMenuItem, InlineLoading } from '@carbon/react';
+import { EmptyState, launchPatientWorkspace, ErrorState, CardHeader } from '@openmrs/esm-patient-common-lib';
+import {
+  OverflowMenu,
+  OverflowMenuItem,
+  InlineLoading,
+  Button,
+  DataTable,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableHeader,
+  TableBody,
+  TableCell,
+} from '@carbon/react';
 import { useClinicalEncounter } from '../../../hooks/useClinicalEncounter';
 import { ConfigObject } from '../../../config-schema';
-import SummaryCard from '../summary-card.component';
 
-import styles from './out-patient-summary.scss';
+import { Add } from '@carbon/react/icons';
 interface OutPatientMedicalHistoryProps {
   patientUuid: string;
 }
@@ -20,6 +32,7 @@ const OutPatientMedicalHistory: React.FC<OutPatientMedicalHistoryProps> = ({ pat
     clinicalEncounterUuid,
     formsList: { clinicalEncounterFormUuid },
   } = useConfig<ConfigObject>();
+  const headerTitle = t('medicalHistory', 'Medical History');
   const { encounters, isLoading, error, mutate, isValidating } = useClinicalEncounter(
     patientUuid,
     clinicalEncounterUuid,
@@ -37,6 +50,28 @@ const OutPatientMedicalHistory: React.FC<OutPatientMedicalHistoryProps> = ({ pat
       },
     });
   };
+  const tableHeader = [
+    {
+      key: 'encounterDate',
+      header: t('encounterDate', 'Date'),
+    },
+    {
+      key: 'surgicalHistory',
+      header: t('surgicalHistory', 'Surgical History'),
+    },
+    {
+      key: 'bloodTransfusion',
+      header: t('bloodTransfusion', 'Blood Transfusion'),
+    },
+    {
+      key: 'accidentOrTrauma',
+      header: t('accidentOrTrauma', 'Accident or Trauma'),
+    },
+    {
+      key: 'finalDiagnosis',
+      header: t('finalDiagnosis', 'Final Diagnosis'),
+    },
+  ];
   const tableRows = encounters?.map((encounter, index) => {
     return {
       id: `${encounter.uuid}`,
@@ -72,17 +107,55 @@ const OutPatientMedicalHistory: React.FC<OutPatientMedicalHistoryProps> = ({ pat
     );
   }
   return (
-    <div className={styles.cardContainer}>
-      {tableRows.map((row, index) => (
-        <React.Fragment key={index}>
-          <SummaryCard title={t('encounterDate', 'Encounter Date')} value={row?.encounterDate} />
-          <SummaryCard title={t('surgicalHistory', 'Surgical History')} value={row?.surgicalHistory} />
-          <SummaryCard title={t('bloodTransfusion', 'Blood Transfusion')} value={row?.bloodTransfusion} />
-          <SummaryCard title={t('accidentOrTrauma', 'Accident/Trauma')} value={row?.accidentOrTrauma} />
-          <SummaryCard title={t('finalDiagnosis', 'Final Diagnosis')} value={row?.finalDiagnosis} />
-        </React.Fragment>
-      ))}
-    </div>
+    <>
+      <CardHeader title={headerTitle}>
+        <Button
+          size="md"
+          kind="ghost"
+          onClick={() => handleOpenOrEditClinicalEncounterForm()}
+          renderIcon={(props) => <Add size={24} {...props} />}
+          iconDescription="Add">
+          {t('add', 'Add')}
+        </Button>
+      </CardHeader>
+      <DataTable
+        size="sm"
+        rows={tableRows}
+        headers={tableHeader}
+        render={({ rows, headers, getHeaderProps, getRowProps, getTableProps, getTableContainerProps }) => (
+          <TableContainer size="sm" {...getTableContainerProps()}>
+            <Table size="sm" {...getTableProps()} aria-label="sample table">
+              <TableHead>
+                <TableRow>
+                  {headers.map((header, i) => (
+                    <TableHeader
+                      key={i}
+                      {...getHeaderProps({
+                        header,
+                      })}>
+                      {header.header}
+                    </TableHeader>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    {...getRowProps({
+                      row,
+                    })}>
+                    {row.cells.map((cell) => (
+                      <TableCell key={cell.id}>{cell.value}</TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      />
+    </>
   );
 };
 export default OutPatientMedicalHistory;

--- a/packages/esm-patient-clinical-view-app/src/clinical-encounter/summary/out-patient-summary/patient-social-history.component.tsx
+++ b/packages/esm-patient-clinical-view-app/src/clinical-encounter/summary/out-patient-summary/patient-social-history.component.tsx
@@ -9,12 +9,24 @@ import {
   Other_Substance_Abuse_UUID,
 } from '../../../utils/constants';
 import { getObsFromEncounter } from '../../../ui/encounter-list/encounter-list-utils';
-import { EmptyState, launchPatientWorkspace, ErrorState } from '@openmrs/esm-patient-common-lib';
-import { OverflowMenu, OverflowMenuItem, InlineLoading } from '@carbon/react';
+import { EmptyState, launchPatientWorkspace, ErrorState, CardHeader } from '@openmrs/esm-patient-common-lib';
+import {
+  OverflowMenu,
+  OverflowMenuItem,
+  InlineLoading,
+  Button,
+  DataTable,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableHeader,
+  TableBody,
+  TableCell,
+} from '@carbon/react';
 import { useClinicalEncounter } from '../../../hooks/useClinicalEncounter';
 import { ConfigObject } from '../../../config-schema';
-import SummaryCard from '../summary-card.component';
-import styles from './out-patient-summary.scss';
+import { Add } from '@carbon/react/icons';
 interface OutPatientSocialHistoryProps {
   patientUuid: string;
 }
@@ -25,6 +37,7 @@ const OutPatientSocialHistory: React.FC<OutPatientSocialHistoryProps> = ({ patie
     clinicalEncounterUuid,
     formsList: { clinicalEncounterFormUuid },
   } = useConfig<ConfigObject>();
+  const headerTitle = t('socialHistory', 'Social History');
   const { encounters, isLoading, error, mutate, isValidating } = useClinicalEncounter(
     patientUuid,
     clinicalEncounterUuid,
@@ -42,6 +55,33 @@ const OutPatientSocialHistory: React.FC<OutPatientSocialHistoryProps> = ({ patie
       },
     });
   };
+  const tableHeader = [
+    {
+      key: 'encounterDate',
+      header: t('encounterDate', 'Date'),
+    },
+    {
+      key: 'alcoholUse',
+      header: t('alcoholUse', 'Alcohol Use'),
+    },
+    {
+      key: 'alcoholUseDuration',
+      header: t('alcoholUseDuration', 'Alcohol Use Duration'),
+    },
+    {
+      key: 'smoking',
+      header: t('smoking', 'Smoking'),
+    },
+    {
+      key: 'smokingDuration',
+      header: t('smokingDuration', 'Smoking Duration'),
+    },
+    {
+      key: 'otherSubstanceAbuse',
+      header: t('otherSubstanceAbuse', 'Other Substance Abuse'),
+    },
+  ];
+
   const tableRows = encounters?.map((encounter, index) => {
     return {
       id: `${encounter.uuid}`,
@@ -78,18 +118,55 @@ const OutPatientSocialHistory: React.FC<OutPatientSocialHistoryProps> = ({ patie
     );
   }
   return (
-    <div className={styles.cardContainer}>
-      {tableRows.map((row, index) => (
-        <React.Fragment key={index}>
-          <SummaryCard title={t('encounterDate', 'Date')} value={row?.encounterDate} />
-          <SummaryCard title={t('alcoholUse', 'Alcohol Use')} value={row?.alcoholUse} />
-          <SummaryCard title={t('alcoholUseDuration', 'Duration')} value={row?.alcoholUseDuration} />
-          <SummaryCard title={t('smoking', 'Tobacco Use')} value={row?.smoking} />
-          <SummaryCard title={t('smokingDuration', 'Duration')} value={row?.smokingDuration} />
-          <SummaryCard title={t('otherSubstanceAbuse', 'Other Substance Use')} value={row?.otherSubstanceAbuse} />
-        </React.Fragment>
-      ))}
-    </div>
+    <>
+      <CardHeader title={headerTitle}>
+        <Button
+          size="md"
+          kind="ghost"
+          onClick={() => handleOpenOrEditClinicalEncounterForm()}
+          renderIcon={(props) => <Add size={24} {...props} />}
+          iconDescription="Add">
+          {t('add', 'Add')}
+        </Button>
+      </CardHeader>
+      <DataTable
+        size="sm"
+        rows={tableRows}
+        headers={tableHeader}
+        render={({ rows, headers, getHeaderProps, getRowProps, getTableProps, getTableContainerProps }) => (
+          <TableContainer size="sm" {...getTableContainerProps()}>
+            <Table size="sm" {...getTableProps()} aria-label="sample table">
+              <TableHead>
+                <TableRow>
+                  {headers.map((header, i) => (
+                    <TableHeader
+                      key={i}
+                      {...getHeaderProps({
+                        header,
+                      })}>
+                      {header.header}
+                    </TableHeader>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    {...getRowProps({
+                      row,
+                    })}>
+                    {row.cells.map((cell) => (
+                      <TableCell key={cell.id}>{cell.value}</TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      />
+    </>
   );
 };
 export default OutPatientSocialHistory;

--- a/packages/esm-patient-clinical-view-app/src/hooks/useClinicalEncounter.ts
+++ b/packages/esm-patient-clinical-view-app/src/hooks/useClinicalEncounter.ts
@@ -3,6 +3,7 @@ import { OpenmrsEncounter } from '../types';
 import { openmrsFetch, useConfig } from '@openmrs/esm-framework';
 import { ConfigObject } from '../config-schema';
 import { clinicalEncounterRepresentation, ClinicalEncounterFormUuid } from '../utils/constants';
+import sortBy from 'lodash/sortBy';
 export function useClinicalEncounter(patientUuid: string, encounterType: string) {
   const config = useConfig() as ConfigObject;
   const url = `/ws/rest/v1/encounter?encounterType=${config.clinicalEncounterUuid}&patient=${patientUuid}&v=${clinicalEncounterRepresentation}`;
@@ -12,9 +13,9 @@ export function useClinicalEncounter(patientUuid: string, encounterType: string)
     openmrsFetch,
   );
   const clinicalEncounter = data?.data?.results?.filter((enc) => enc.form.uuid === ClinicalEncounterFormUuid);
-
+  const sortedClinicalEncounter = sortBy(clinicalEncounter, 'encounterDatetime').reverse();
   return {
-    encounters: clinicalEncounter,
+    encounters: sortedClinicalEncounter,
     isLoading,
     isValidating,
     error,

--- a/packages/esm-patient-clinical-view-app/src/special-clinics/hiv-care-and-treatment-services/defaulter-tracing/defaulter-tracing.component.tsx
+++ b/packages/esm-patient-clinical-view-app/src/special-clinics/hiv-care-and-treatment-services/defaulter-tracing/defaulter-tracing.component.tsx
@@ -15,14 +15,11 @@ import {
   DataTable,
   TableContainer,
   Table,
-  TableExpandRow,
   TableHead,
   TableRow,
-  TableExpandHeader,
   TableHeader,
   TableBody,
   TableCell,
-  TableExpandedRow,
   OverflowMenu,
   OverflowMenuItem,
   DataTableSkeleton,
@@ -147,21 +144,11 @@ const DefaulterTracing: React.FC<PatientTracingProps> = ({ patientUuid, encounte
         size="sm"
         rows={tableRows}
         headers={tableHeader}
-        render={({
-          rows,
-          headers,
-          getHeaderProps,
-          getExpandHeaderProps,
-          getRowProps,
-          getExpandedRowProps,
-          getTableProps,
-          getTableContainerProps,
-        }) => (
+        render={({ rows, headers, getHeaderProps, getRowProps, getTableProps, getTableContainerProps }) => (
           <TableContainer size="sm" {...getTableContainerProps()}>
             <Table size="sm" {...getTableProps()} aria-label="sample table">
               <TableHead>
                 <TableRow>
-                  <TableExpandHeader enableToggle={true} {...getExpandHeaderProps()} />
                   {headers.map((header, i) => (
                     <TableHeader
                       key={i}
@@ -175,24 +162,15 @@ const DefaulterTracing: React.FC<PatientTracingProps> = ({ patientUuid, encounte
               </TableHead>
               <TableBody>
                 {rows.map((row) => (
-                  <React.Fragment key={row.id}>
-                    <TableExpandRow
-                      {...getRowProps({
-                        row,
-                      })}>
-                      {row.cells.map((cell) => (
-                        <TableCell key={cell.id}>{cell.value}</TableCell>
-                      ))}
-                    </TableExpandRow>
-                    <TableExpandedRow
-                      colSpan={headers.length + 1}
-                      className="demo-expanded-td"
-                      {...getExpandedRowProps({
-                        row,
-                      })}>
-                      <h6>To do...</h6>
-                    </TableExpandedRow>
-                  </React.Fragment>
+                  <TableRow
+                    key={row.id}
+                    {...getRowProps({
+                      row,
+                    })}>
+                    {row.cells.map((cell) => (
+                      <TableCell key={cell.id}>{cell.value}</TableCell>
+                    ))}
+                  </TableRow>
                 ))}
               </TableBody>
             </Table>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7843,9 +7843,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001335, caniuse-lite@npm:^1.0.30001400":
-  version: 1.0.30001506
-  resolution: "caniuse-lite@npm:1.0.30001506"
-  checksum: 10c60eee8dcf767acf5e613d7bb98feac4b57d4a0df8e3f9d42026909951b540cf3e16294e9968daa3b7929a839e922e3bd9072e8e439c2b268a945cc69d43bd
+  version: 1.0.30001583
+  resolution: "caniuse-lite@npm:1.0.30001583"
+  checksum: 8e7b5ffeb1229efacc1022fbe19eb136f39e4512363322d175e836fef9d798d7308a0763ce654670d45a55c3f25f34c12f87e90e1da34c5d9531fac2327d2063
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Revamed clinical encounter views to use a table instead of summary cards to avoid repeated column headers.
Changed defaulter tracing view from expandable table to classic table.

## Screenshots
![ClinicalEncRevamped](https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/11721739/2dee579f-01df-4caa-91f5-8eb409b2b883)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
