### PR TITLE
(feat) Adapt billing checkin form to use extra-visit attribute slot

### DIFF
--- a/packages/esm-billing-app/src/billing-form/billing-checkin-form.component.tsx
+++ b/packages/esm-billing-app/src/billing-form/billing-checkin-form.component.tsx
@@ -11,10 +11,10 @@ import { EXEMPTED_PAYMENT_STATUS, PENDING_PAYMENT_STATUS } from '../constants';
 
 type BillingCheckInFormProps = {
   patientUuid: string;
-  setBillingInfo: (state) => void;
+  setExtraVisitInfo: (state) => void;
 };
 
-const BillingCheckInForm: React.FC<BillingCheckInFormProps> = ({ patientUuid, setBillingInfo }) => {
+const BillingCheckInForm: React.FC<BillingCheckInFormProps> = ({ patientUuid, setExtraVisitInfo }) => {
   const { t } = useTranslation();
   const {
     visitAttributeTypes: { isPatientExempted },
@@ -70,7 +70,10 @@ const BillingCheckInForm: React.FC<BillingCheckInFormProps> = ({ patientUuid, se
       payments: [],
     };
 
-    setBillingInfo({ createBillPayload, handleCreateBill: () => handleCreateBill(createBillPayload), attributes });
+    setExtraVisitInfo({
+      handleCreateExtraVisitInfo: () => handleCreateBill(createBillPayload),
+      attributes,
+    });
   };
 
   if (isLoadingLineItems || isLoadingCashPoints) {

--- a/packages/esm-billing-app/src/routes.json
+++ b/packages/esm-billing-app/src/routes.json
@@ -47,8 +47,8 @@
       }
     },
     {
-      "name": "billing-checkin-form",
-      "slot": "billing-checkin-slot",
+      "name": "billing-check-in-form",
+      "slot": "extra-visit-attribute-slot",
       "component": "billingCheckInForm"
     },
     {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR adapts billing check in form to use `extra-visit-attribute-slot` relating to the merged [PR](https://github.com/openmrs/openmrs-esm-patient-chart/pull/1700) 


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
