### PR TITLE
(fix) fix share `@openmrs/esm-patient-common-lib` leading to run time error

### DIFF
--- a/packages/esm-morgue-app/package.json
+++ b/packages/esm-morgue-app/package.json
@@ -38,12 +38,12 @@
   },
   "dependencies": {
     "@carbon/react": "^1.42.1",
-    "@openmrs/esm-patient-common-lib": "next",
     "lodash-es": "^4.17.15",
     "react-to-print": "^2.14.13"
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
+    "@openmrs/esm-patient-common-lib": "*",
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2677,6 +2677,7 @@ __metadata:
     webpack: "npm:^5.74.0"
   peerDependencies:
     "@openmrs/esm-framework": 5.x
+    "@openmrs/esm-patient-common-lib": "*"
     react: ^18.1.0
     react-i18next: 11.x
     react-router-dom: 6.x


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Moving `@openmrs/esm-patient-common-lib` to peer dependency since having it as a dependency bundles it in the generate dist and results in error at run time as there are multiple versions of the same dependency. cc @ojwanganto this resolves the error you are seeing while launching the workspace. Thanks


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
