### PR TITLE
O3-3128: Add ability to show lab and drug order prices and stock levels

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billiable-item/drug-order.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/drug-order.component.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Drug } from '@openmrs/esm-patient-common-lib';
+import { DosingUnit, MedicationFrequency, MedicationRoute, QuantityUnit } from '../../types';
+import { useBillableItem, useSockItemInventory } from './useBilliableItem';
+import { useTranslation } from 'react-i18next';
+import styles from './drug-order.scss';
+import { convertToCurrency } from '../../helpers';
+
+type DrugOrderProps = {
+  order: {
+    drug: Drug;
+    unit: DosingUnit;
+    commonMedicationName: string;
+    dosage: number;
+    frequency: MedicationFrequency;
+    route: MedicationRoute;
+    quantityUnits: QuantityUnit;
+    patientInstructions: string;
+    asNeeded: boolean;
+    asNeededCondition: string;
+  };
+};
+
+const DrugOrder: React.FC<DrugOrderProps> = ({ order }) => {
+  const { t } = useTranslation();
+  const { stockItem, isLoading: isLoadingInventory } = useSockItemInventory(order?.drug?.uuid);
+  const { billableItem, isLoading } = useBillableItem(order?.drug.concept.uuid);
+
+  if (isLoading || isLoadingInventory) {
+    return null;
+  }
+
+  return (
+    <div className={styles.drugOrderContainer}>
+      {stockItem && (
+        <div className={styles.itemContainer}>
+          <span className={styles.bold}>
+            {t('inStock', '{{quantityUoM}}(s) In stock ', { quantityUoM: stockItem?.quantityUoM })}
+          </span>
+          <span>{Math.round(stockItem?.quantity)}</span>
+        </div>
+      )}
+      <div>
+        {billableItem &&
+          billableItem?.servicePrices.map((item) => (
+            <div key={item.uuid} className={styles.itemContainer}>
+              <span className={styles.bold}>{t('unitPrice', 'Unit price ')}</span>
+              <span>{convertToCurrency(item.price)}</span>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+};
+
+export default DrugOrder;

--- a/packages/esm-billing-app/src/billable-services/billiable-item/drug-order.scss
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/drug-order.scss
@@ -1,0 +1,26 @@
+@use '@carbon/type';
+@use '@carbon/colors';
+@use '@carbon/layout';
+@use '@carbon/styles/scss/spacing';
+
+.drugOrderContainer {
+  margin: spacing.$spacing-03 0;
+
+  & > div {
+    margin: spacing.$spacing-03 0;
+  }
+}
+
+.bold {
+  font-weight: bold;
+}
+
+.itemInfo {
+  @include type.type-style('body-01');
+}
+
+.itemContainer {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  padding-left: spacing.$spacing-03;
+}

--- a/packages/esm-billing-app/src/billable-services/billiable-item/lab-order.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/lab-order.component.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { convertToCurrency } from '../../helpers';
+import { useBillableItem } from './useBilliableItem';
+
+type LabOrderProps = {
+  order: {
+    testType?: {
+      label: string;
+      conceptUuid: string;
+    };
+  };
+};
+
+const LabOrder: React.FC<LabOrderProps> = ({ order }) => {
+  // TODO: Implement logic to display whether the lab order service is available to ensure clinicians can order the service
+
+  const { billableItem, error, isLoading } = useBillableItem(order?.testType?.conceptUuid);
+
+  const billItems = billableItem?.servicePrices
+    .map((servicePrice) => `${servicePrice?.paymentMode?.name} - ${convertToCurrency(servicePrice?.price)}`)
+    .join(' ');
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (error) {
+    return null;
+  }
+
+  return <p>{billItems}</p>;
+};
+
+export default LabOrder;

--- a/packages/esm-billing-app/src/billable-services/billiable-item/useBilliableItem.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/useBilliableItem.tsx
@@ -1,0 +1,50 @@
+import useSWRImmutable from 'swr/immutable';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import useSWR from 'swr';
+import first from 'lodash-es/first';
+
+type BillableItemResponse = {
+  uuid: string;
+  name: string;
+  concept: {
+    uuid: string;
+    display: string;
+  };
+  servicePrices: Array<{
+    uuid: string;
+    price: number;
+    paymentMode: {
+      uuid: string;
+      name: string;
+    };
+  }>;
+};
+
+export const useBillableItem = (billableItemId: string) => {
+  const customRepresentation = `v=custom:(uuid,name,concept:(uuid,display),servicePrices:(uuid,price,paymentMode:(uuid,name)))`;
+  const { data, error, isLoading } = useSWRImmutable<{ data: { results: Array<BillableItemResponse> } }>(
+    `${restBaseUrl}/cashier/billableService?${customRepresentation}`,
+    openmrsFetch,
+  );
+  const billableItem = data?.data?.results?.find((item) => item?.concept?.uuid === billableItemId);
+
+  return {
+    billableItem: billableItem,
+    isLoading: isLoading,
+    error,
+  };
+};
+
+export const useSockItemInventory = (stockItemId: string) => {
+  const url = `/ws/rest/v1/stockmanagement/stockiteminventory?v=default&limit=10&totalCount=true&drugUuid=${stockItemId}`;
+  const { data, error, isLoading } = useSWR<{ data: { results: Array<{ quantityUoM: string; quantity: number }> } }>(
+    url,
+    openmrsFetch,
+  );
+  const stockItemsInfo = first(data?.data?.results ?? []);
+  return {
+    stockItem: stockItemsInfo,
+    isLoading: isLoading,
+    error,
+  };
+};

--- a/packages/esm-billing-app/src/index.ts
+++ b/packages/esm-billing-app/src/index.ts
@@ -13,6 +13,8 @@ import RequirePaymentModal from './modal/require-payment-modal.component';
 import VisitAttributeTags from './invoice/payments/visit-tags/visit-attribute.component';
 import InitiatePaymentDialog from './invoice/payments/initiate-payment/initiate-payment.component';
 import BillingPrompt from './billing-prompt/billing-prompt.component';
+import DrugOrder from './billable-services/billiable-item/drug-order.component';
+import LabOrder from './billable-services/billiable-item/lab-order.component';
 
 const moduleName = '@kenyaemr/esm-billing-app';
 
@@ -50,3 +52,5 @@ export const requirePaymentModal = getSyncLifecycle(RequirePaymentModal, options
 export const visitAttributeTags = getSyncLifecycle(VisitAttributeTags, options);
 export const initiatePaymentDialog = getSyncLifecycle(InitiatePaymentDialog, options);
 export const billingPrompt = getSyncLifecycle(BillingPrompt, options);
+export const labOrder = getSyncLifecycle(LabOrder, options);
+export const drugOrder = getSyncLifecycle(DrugOrder, options);

--- a/packages/esm-billing-app/src/routes.json
+++ b/packages/esm-billing-app/src/routes.json
@@ -79,6 +79,16 @@
     {
       "name": "initiate-payment-modal",
       "component": "initiatePaymentDialog"
+    },
+    {
+      "name": "lab-order-billable-item",
+      "component": "labOrder",
+      "slot": "top-of-lab-order-form-slot"
+    },
+    {
+      "name": "drug-order-billable-item",
+      "component": "drugOrder",
+      "slot": "medication-info-slot"
     }
   ]
 }

--- a/packages/esm-billing-app/src/types/index.ts
+++ b/packages/esm-billing-app/src/types/index.ts
@@ -1,3 +1,4 @@
+import { type Drug, type OrderBasketItem } from '@openmrs/esm-patient-common-lib';
 export interface MappedBill {
   uuid: string;
   id: number;
@@ -175,3 +176,77 @@ export type BillingService = {
   shortName: string;
   uuid: string;
 };
+
+export interface DrugOrderBasketItem extends OrderBasketItem {
+  drug: Drug;
+  unit: DosingUnit;
+  commonMedicationName: string;
+  dosage: number;
+  frequency: MedicationFrequency;
+  route: MedicationRoute;
+  quantityUnits: QuantityUnit;
+  patientInstructions: string;
+  asNeeded: boolean;
+  asNeededCondition: string;
+  // TODO: This is unused
+  startDate: Date | string;
+  durationUnit: DurationUnit;
+  duration: number | null;
+  pillsDispensed: number;
+  numRefills: number;
+  indication: string;
+  isFreeTextDosage: boolean;
+  freeTextDosage: string;
+  previousOrder?: string;
+  template?: OrderTemplate;
+}
+
+export interface DrugOrderTemplate {
+  uuid: string;
+  name: string;
+  drug: Drug;
+  template: OrderTemplate;
+}
+
+export interface OrderTemplate {
+  type: string;
+  dosingType: string;
+  dosingInstructions: DosingInstructions;
+}
+
+export interface DosingInstructions {
+  dose: Array<MedicationDosage>;
+  units: Array<DosingUnit>;
+  route: Array<MedicationRoute>;
+  frequency: Array<MedicationFrequency>;
+  instructions?: Array<MedicationInstructions>;
+  durationUnits?: Array<DurationUnit>;
+  quantityUnits?: Array<QuantityUnit>;
+  asNeeded?: boolean;
+  asNeededCondition?: string;
+}
+
+export interface MedicationDosage extends Omit<CommonMedicationProps, 'value'> {
+  value: number;
+}
+
+export type MedicationFrequency = CommonMedicationValueCoded;
+
+export type MedicationRoute = CommonMedicationValueCoded;
+
+export type MedicationInstructions = CommonMedicationProps;
+
+export type DosingUnit = CommonMedicationValueCoded;
+
+export type QuantityUnit = CommonMedicationValueCoded;
+
+export type DurationUnit = CommonMedicationValueCoded;
+
+interface CommonMedicationProps {
+  value: string;
+  default?: boolean;
+}
+
+export interface CommonMedicationValueCoded extends CommonMedicationProps {
+  valueCoded: string;
+}

--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -49,6 +49,7 @@
   "initiatePay": "Initiate Payment",
   "initiatePayment": "Initiate Payment",
   "inlineLoading": "Loading bill items...",
+  "inStock": "{{quantityUoM}}(s) In stock ",
   "insuranceScheme": "Insurance scheme",
   "invalidSHANumber": "SHA number is invalid, advice patient to update payment or contact SHA",
   "invalidWaiverAmount": "Invalid waiver amount",

--- a/packages/esm-morgue-app/package.json
+++ b/packages/esm-morgue-app/package.json
@@ -38,12 +38,12 @@
   },
   "dependencies": {
     "@carbon/react": "^1.42.1",
-    "@openmrs/esm-patient-common-lib": "next",
     "lodash-es": "^4.17.15",
     "react-to-print": "^2.14.13"
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
+    "@openmrs/esm-patient-common-lib": "*",
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2677,6 +2677,7 @@ __metadata:
     webpack: "npm:^5.74.0"
   peerDependencies:
     "@openmrs/esm-framework": 5.x
+    "@openmrs/esm-patient-common-lib": "*"
     react: ^18.1.0
     react-i18next: 11.x
     react-router-dom: 6.x


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

see 👉🏽  https://openmrs.atlassian.net/browse/O3-3128


## Screenshots
https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/28008754/bfb391e7-920d-406b-9205-983b71a0a39a

## Related Issue
https://github.com/openmrs/openmrs-esm-patient-chart/pull/1818
## Other
@ojwanganto @patryllus  we will need to update the stock inventory endpoint to allow clinical staff access stock levels. 
*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
