### PR TITLE
(fix) Align `@openmrs/esm-patient-common-lib` to use one version provided by patient-chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@openmrs/esm-framework": "next",
+    "@openmrs/esm-patient-common-lib": "next",
     "@playwright/test": "^1.30.0",
     "@swc/cli": "^0.1.57",
     "@swc/core": "^1.2.165",

--- a/packages/esm-billing-app/package.json
+++ b/packages/esm-billing-app/package.json
@@ -38,19 +38,18 @@
   },
   "dependencies": {
     "@carbon/react": "^1.42.1",
-    "@openmrs/esm-patient-common-lib": "next",
     "lodash-es": "^4.17.15",
     "react-to-print": "^2.14.13"
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
+    "@openmrs/esm-patient-common-lib": "7.x",
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "swr": "2.x"
   },
   "devDependencies": {
-    "@openmrs/esm-patient-common-lib": "next",
     "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-care-panel-app/package.json
+++ b/packages/esm-care-panel-app/package.json
@@ -50,7 +50,6 @@
     "swr": "2.x"
   },
   "devDependencies": {
-    "@openmrs/esm-patient-common-lib": "next",
     "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-claims-app/package.json
+++ b/packages/esm-claims-app/package.json
@@ -38,19 +38,18 @@
   },
   "dependencies": {
     "@carbon/react": "^1.42.1",
-    "@openmrs/esm-patient-common-lib": "next",
     "lodash-es": "^4.17.15",
     "react-to-print": "^2.14.13"
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
+    "@openmrs/esm-patient-common-lib": "7.x",
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "swr": "2.x"
   },
   "devDependencies": {
-    "@openmrs/esm-patient-common-lib": "next",
     "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-morgue-app/package.json
+++ b/packages/esm-morgue-app/package.json
@@ -43,14 +43,13 @@
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "5.x",
-    "@openmrs/esm-patient-common-lib": "*",
+    "@openmrs/esm-patient-common-lib": "7.x",
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x",
     "swr": "2.x"
   },
   "devDependencies": {
-    "@openmrs/esm-patient-common-lib": "next",
     "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-patient-clinical-view-app/package.json
+++ b/packages/esm-patient-clinical-view-app/package.json
@@ -48,7 +48,6 @@
     "react-router-dom": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-patient-common-lib": "next",
     "webpack": "^5.74.0"
   }
 }

--- a/packages/esm-shr-app/package.json
+++ b/packages/esm-shr-app/package.json
@@ -42,13 +42,12 @@
     "react-to-print": "^2.14.13"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "5.x",
+    "@openmrs/esm-framework": "7.x",
     "react": "^18.1.0",
     "react-i18next": "11.x",
     "react-router-dom": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-patient-common-lib": "next",
     "webpack": "^5.74.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2552,6 +2552,7 @@ __metadata:
   dependencies:
     "@hookform/resolvers": "npm:^3.1.1"
     "@openmrs/esm-framework": "npm:next"
+    "@openmrs/esm-patient-common-lib": "npm:next"
     "@playwright/test": "npm:^1.30.0"
     "@swc/cli": "npm:^0.1.57"
     "@swc/core": "npm:^1.2.165"
@@ -2616,12 +2617,12 @@ __metadata:
   resolution: "@kenyaemr/esm-billing-app@workspace:packages/esm-billing-app"
   dependencies:
     "@carbon/react": "npm:^1.42.1"
-    "@openmrs/esm-patient-common-lib": "npm:next"
     lodash-es: "npm:^4.17.15"
     react-to-print: "npm:^2.14.13"
     webpack: "npm:^5.74.0"
   peerDependencies:
     "@openmrs/esm-framework": 5.x
+    "@openmrs/esm-patient-common-lib": 7.x
     react: ^18.1.0
     react-i18next: 11.x
     react-router-dom: 6.x
@@ -2634,7 +2635,6 @@ __metadata:
   resolution: "@kenyaemr/esm-care-panel-app@workspace:packages/esm-care-panel-app"
   dependencies:
     "@carbon/react": "npm:^1.42.1"
-    "@openmrs/esm-patient-common-lib": "npm:next"
     lodash-es: "npm:^4.17.15"
     react-to-print: "npm:^2.14.13"
     webpack: "npm:^5.74.0"
@@ -2653,12 +2653,12 @@ __metadata:
   resolution: "@kenyaemr/esm-claims-app@workspace:packages/esm-claims-app"
   dependencies:
     "@carbon/react": "npm:^1.42.1"
-    "@openmrs/esm-patient-common-lib": "npm:next"
     lodash-es: "npm:^4.17.15"
     react-to-print: "npm:^2.14.13"
     webpack: "npm:^5.74.0"
   peerDependencies:
     "@openmrs/esm-framework": 5.x
+    "@openmrs/esm-patient-common-lib": 7.x
     react: ^18.1.0
     react-i18next: 11.x
     react-router-dom: 6.x
@@ -2671,13 +2671,12 @@ __metadata:
   resolution: "@kenyaemr/esm-morgue-app@workspace:packages/esm-morgue-app"
   dependencies:
     "@carbon/react": "npm:^1.42.1"
-    "@openmrs/esm-patient-common-lib": "npm:next"
     lodash-es: "npm:^4.17.15"
     react-to-print: "npm:^2.14.13"
     webpack: "npm:^5.74.0"
   peerDependencies:
     "@openmrs/esm-framework": 5.x
-    "@openmrs/esm-patient-common-lib": "*"
+    "@openmrs/esm-patient-common-lib": 7.x
     react: ^18.1.0
     react-i18next: 11.x
     react-router-dom: 6.x
@@ -2690,7 +2689,6 @@ __metadata:
   resolution: "@kenyaemr/esm-patient-clinical-view-app@workspace:packages/esm-patient-clinical-view-app"
   dependencies:
     "@carbon/react": "npm:^1.42.1"
-    "@openmrs/esm-patient-common-lib": "npm:next"
     lodash-es: "npm:^4.17.15"
     webpack: "npm:^5.74.0"
   peerDependencies:
@@ -2722,12 +2720,11 @@ __metadata:
   resolution: "@kenyaemr/esm-shr-app@workspace:packages/esm-shr-app"
   dependencies:
     "@carbon/react": "npm:^1.42.1"
-    "@openmrs/esm-patient-common-lib": "npm:next"
     lodash-es: "npm:^4.17.15"
     react-to-print: "npm:^2.14.13"
     webpack: "npm:^5.74.0"
   peerDependencies:
-    "@openmrs/esm-framework": 5.x
+    "@openmrs/esm-framework": 7.x
     react: ^18.1.0
     react-i18next: 11.x
     react-router-dom: 6.x


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Align `@openmrs/esm-patient-common-lib` package to squash error on launching workspaces.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
