### PR TITLE
(feat) KHP3-5867 : Add restriction to require an active visit before launching billing form

### DIFF
--- a/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
+++ b/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
@@ -19,8 +19,14 @@ import {
   Button,
 } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
-import { isDesktop, useLayoutType, usePagination, launchWorkspace } from '@openmrs/esm-framework';
-import { EmptyDataIllustration, ErrorState, usePaginationInfo, CardHeader } from '@openmrs/esm-patient-common-lib';
+import { isDesktop, useLayoutType, usePagination } from '@openmrs/esm-framework';
+import {
+  EmptyDataIllustration,
+  ErrorState,
+  usePaginationInfo,
+  CardHeader,
+  useLaunchWorkspaceRequiringVisit,
+} from '@openmrs/esm-patient-common-lib';
 import { useBills } from '../billing.resource';
 import InvoiceTable from '../invoice/invoice-table.component';
 import styles from './bill-history.scss';
@@ -32,11 +38,16 @@ interface BillHistoryProps {
 const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
   const { t } = useTranslation();
   const { bills, isLoading, error } = useBills(patientUuid);
+  const launchPatientWorkspace = useLaunchWorkspaceRequiringVisit('billing-form');
   const layout = useLayoutType();
   const [pageSize, setPageSize] = React.useState(10);
   const responsiveSize = isDesktop(layout) ? 'sm' : 'lg';
   const { paginated, goTo, results, currentPage } = usePagination(bills, pageSize);
   const { pageSizes } = usePaginationInfo(pageSize, bills?.length, currentPage, results?.length);
+
+  const handleLaunchBillForm = () => {
+    launchPatientWorkspace({ workspaceTitle: t('billingForm', 'Billing Form') });
+  };
 
   const headerData = [
     {
@@ -58,7 +69,7 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
   ];
 
   const setBilledItems = (bill) =>
-    bill.lineItems.reduce(
+    bill.lineItems?.reduce(
       (acc, item) => acc + (acc ? ' & ' : '') + (item.billableService?.split(':')[1] || item.item?.split(':')[1] || ''),
       '',
     );
@@ -102,7 +113,7 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
               <EmptyDataIllustration />
             </div>
             <p className={styles.content}>There are no bills to display.</p>
-            <Button onClick={() => launchWorkspace('billing-form', { workspaceTitle: 'Billing Form' })} kind="ghost">
+            <Button onClick={handleLaunchBillForm} kind="ghost">
               {t('launchBillForm', 'Launch bill form')}
             </Button>
           </Tile>
@@ -114,10 +125,7 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
   return (
     <div>
       <CardHeader title={t('patientBilling', 'Patient billing')}>
-        <Button
-          renderIcon={Add}
-          onClick={() => launchWorkspace('billing-form', { workspaceTitle: 'Billing Form' })}
-          kind="ghost">
+        <Button renderIcon={Add} onClick={handleLaunchBillForm} kind="ghost">
           {t('addBill', 'Add bill item(s)')}
         </Button>
       </CardHeader>

--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -17,6 +17,7 @@
   "billedTo": "Billed to",
   "billErrorService": "Bill service error",
   "billing": "Billing",
+  "billingForm": "Billing Form",
   "billingStatus": "Billing status",
   "billItem": "Bill item",
   "billItems": "Save Bill",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2651,23 +2651,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kenyaemr/esm-claims-app@workspace:packages/esm-claims-app":
-  version: 0.0.0-use.local
-  resolution: "@kenyaemr/esm-claims-app@workspace:packages/esm-claims-app"
-  dependencies:
-    "@carbon/react": "npm:^1.42.1"
-    lodash-es: "npm:^4.17.15"
-    react-to-print: "npm:^2.14.13"
-    webpack: "npm:^5.74.0"
-  peerDependencies:
-    "@openmrs/esm-framework": 5.x
-    react: ^18.1.0
-    react-i18next: 11.x
-    react-router-dom: 6.x
-    swr: 2.x
-  languageName: unknown
-  linkType: soft
-
 "@kenyaemr/esm-morgue-app@workspace:packages/esm-morgue-app":
   version: 0.0.0-use.local
   resolution: "@kenyaemr/esm-morgue-app@workspace:packages/esm-morgue-app"


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

see https://thepalladiumgroup.atlassian.net/browse/KHP3-5867


## Screenshots
https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/28008754/e5f1ae79-b0de-42fc-ae24-e565cfec0fdd




## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
