### PR TITLE
(fix) : fix error on picking the correct bill total amount

### DIFF
--- a/packages/esm-billing-app/src/invoice/payments/payments.component.tsx
+++ b/packages/esm-billing-app/src/invoice/payments/payments.component.tsx
@@ -45,7 +45,7 @@ const Payments: React.FC<PaymentProps> = ({ bill, selectedLineItems }) => {
   const hasMoreThanOneLineItem = bill?.lineItems?.length > 1;
   const computedTotal = hasMoreThanOneLineItem ? computeTotalPrice(selectedLineItems) : bill.totalAmount ?? 0;
   const totalAmountTendered = formValues?.reduce((curr: number, prev) => curr + Number(prev.amount) ?? 0, 0) ?? 0;
-  const amountDue = Number(computedTotal) - (Number(bill.tenderedAmount) + Number(totalAmountTendered));
+  const amountDue = Number(bill.totalAmount) - (Number(bill.tenderedAmount) + Number(totalAmountTendered));
 
   const handleNavigateToBillingDashboard = () =>
     navigate({
@@ -94,7 +94,7 @@ const Payments: React.FC<PaymentProps> = ({ bill, selectedLineItems }) => {
         </div>
         <div className={styles.divider} />
         <div className={styles.paymentTotals}>
-          <InvoiceBreakDown label={t('totalAmount', 'Total Amount')} value={convertToCurrency(computedTotal)} />
+          <InvoiceBreakDown label={t('totalAmount', 'Total Amount')} value={convertToCurrency(bill.totalAmount)} />
           <InvoiceBreakDown
             label={t('totalTendered', 'Total Tendered')}
             value={convertToCurrency(bill.tenderedAmount + totalAmountTendered ?? 0)}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Change total amount to reflect correctly in the invoice breakdown Change client balance/total amount due to show correct balance on posted bills


## Screenshots
https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/35590825/9c85e711-f7cf-474d-99fd-0ca142231583


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
