### PR TITLE
(fix) KHP3-5878 : Fix defaulter tracing form not launching on patient chart

### DIFF
--- a/packages/esm-care-panel-app/src/program-enrollment/program-enrollment.component.tsx
+++ b/packages/esm-care-panel-app/src/program-enrollment/program-enrollment.component.tsx
@@ -16,7 +16,7 @@ import {
 import styles from './program-enrollment.scss';
 import isEmpty from 'lodash/isEmpty';
 import dayjs from 'dayjs';
-import { formatDate, launchWorkspace } from '@openmrs/esm-framework';
+import { formatDate } from '@openmrs/esm-framework';
 import orderBy from 'lodash/orderBy';
 import { mutate } from 'swr';
 import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';

--- a/packages/esm-patient-clinical-view-app/src/maternal-and-child-health/partography/partograph.component.tsx
+++ b/packages/esm-patient-clinical-view-app/src/maternal-and-child-health/partography/partograph.component.tsx
@@ -15,8 +15,8 @@ import {
   Button,
 } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
-import { EmptyDataIllustration, ErrorState, CardHeader } from '@openmrs/esm-patient-common-lib';
-import { formatDate, isDesktop, launchWorkspace, useLayoutType } from '@openmrs/esm-framework';
+import { EmptyDataIllustration, ErrorState, CardHeader, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import { formatDate, isDesktop, useLayoutType } from '@openmrs/esm-framework';
 import styles from './labour-delivery.scss';
 import { usePartograph } from '../../hooks/usePartograph';
 import dayjs from 'dayjs';
@@ -83,7 +83,7 @@ const Partograph: React.FC<PartographyProps> = ({ patientUuid }) => {
     }) ?? [];
 
   const handleAddHistory = () => {
-    launchWorkspace('patient-form-entry-workspace', {
+    launchPatientWorkspace('patient-form-entry-workspace', {
       workspaceTitle: headerTitle,
       mutateForm: () => {
         mutate();

--- a/packages/esm-patient-clinical-view-app/src/specialized-clinics/hiv-care-and-treatment-services/defaulter-tracing/defaulter-tracing.component.tsx
+++ b/packages/esm-patient-clinical-view-app/src/specialized-clinics/hiv-care-and-treatment-services/defaulter-tracing/defaulter-tracing.component.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { formatDate, launchWorkspace, parseDate, useConfig } from '@openmrs/esm-framework';
+import { formatDate, parseDate, useConfig } from '@openmrs/esm-framework';
 import {
   Contacted_UUID,
   MissedAppointmentDate_UUID,
@@ -9,7 +9,7 @@ import {
   TracingType_UUID,
 } from '../../../utils/constants';
 import { getObsFromEncounter } from '../../../ui/encounter-list/encounter-list-utils';
-import { CardHeader, EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
+import { CardHeader, EmptyState, ErrorState, launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import {
   Button,
   DataTable,
@@ -29,8 +29,6 @@ import { ConfigObject } from '../../../config-schema';
 import { Add } from '@carbon/react/icons';
 interface PatientTracingProps {
   patientUuid: string;
-  encounterTypeUuid: string;
-  formEntrySub: any;
 }
 
 const DefaulterTracing: React.FC<PatientTracingProps> = ({ patientUuid }) => {
@@ -44,7 +42,7 @@ const DefaulterTracing: React.FC<PatientTracingProps> = ({ patientUuid }) => {
     defaulterTracingEncounterUuid,
   );
   const handleOpenOrEditDefaulterTracingForm = (encounterUUID = '') => {
-    launchWorkspace('patient-form-entry-workspace', {
+    launchPatientWorkspace('patient-form-entry-workspace', {
       workspaceTitle: 'Defaulter Tracing',
       mutateForm: mutate,
       formInfo: {

--- a/packages/esm-patient-clinical-view-app/src/specialized-clinics/hiv-care-and-treatment-services/defaulter-tracing/defaulter-tracing.test.tsx
+++ b/packages/esm-patient-clinical-view-app/src/specialized-clinics/hiv-care-and-treatment-services/defaulter-tracing/defaulter-tracing.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import DefaulterTracing from './defaulter-tracing.component';
+import { usePatientTracing } from '../../../hooks/usePatientTracing';
+import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
+import useEvent from '@testing-library/user-event';
+
+const usePatientTracingMock = usePatientTracing as jest.MockedFunction<typeof usePatientTracing>;
+const launchPatientWorkspaceMock = launchPatientWorkspace as jest.MockedFunction<typeof launchPatientWorkspace>;
+
+jest.mock('../../../hooks/usePatientTracing', () => ({
+  defaulterTracingEncounterUuid: 'some-uuid',
+  usePatientTracing: jest.fn(),
+}));
+
+jest.mock('@openmrs/esm-patient-common-lib', () => ({
+  ...jest.requireActual('@openmrs/esm-patient-common-lib'),
+  launchPatientWorkspace: jest.fn(),
+}));
+
+jest.mock('@openmrs/esm-framework', () => ({
+  ...jest.requireActual('@openmrs/esm-framework'),
+  useConfig: jest.fn(() => ({
+    formsList: {
+      defaulterTracingFormUuid: 'defaulterTracingFormUuid',
+    },
+  })),
+}));
+
+describe('DefaulterTracing', () => {
+  test('should launch `Defaulter Tracing` form', async () => {
+    const user = useEvent.setup();
+    usePatientTracingMock.mockReturnValue({
+      encounters: [],
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+      isValidating: false,
+    });
+    render(<DefaulterTracing patientUuid="patientUuid" />);
+    const recordDefaulterTracing = screen.getByRole('button', { name: /Record Defaulter Tracing/i });
+    await user.click(recordDefaulterTracing);
+    expect(launchPatientWorkspaceMock).toBeCalledWith('patient-form-entry-workspace', {
+      formInfo: {
+        encounterUuid: '',
+        formUuid: 'defaulterTracingFormUuid',
+        patientUuid: 'patientUuid',
+        visitTypeUuid: '',
+        visitUuid: '',
+      },
+      mutateForm: expect.any(Function),
+      workspaceTitle: 'Defaulter Tracing',
+    });
+  });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

See https://thepalladiumgroup.atlassian.net/browse/KHP3-5878


## Screenshots
https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/28008754/04a68274-1de7-4ef9-b72c-a3d347780f1e


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
