### PR TITLE
(fix) fix showing picking lab order action button

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.component.tsx
@@ -7,6 +7,10 @@ import { showModal } from '@openmrs/esm-framework';
 
 type TestOrderProps = { order: Order };
 
+enum FulfillerStatus {
+  IN_PROGRESS = 'IN_PROGRESS',
+}
+
 const TestOrderAction: React.FC<TestOrderProps> = ({ order }) => {
   const { t } = useTranslation();
   const { isLoading, hasPendingPayment } = useTestOrderBillStatus(order.uuid, order.patient.uuid);
@@ -22,6 +26,11 @@ const TestOrderAction: React.FC<TestOrderProps> = ({ order }) => {
   // 1. The current visit is in-patient
   // 2. The test order has been paid in full
   // 3. The patient is an emergency patient
+
+  // If the order is in progress, do not show the action
+  if (order.fulfillerStatus === FulfillerStatus.IN_PROGRESS) {
+    return null;
+  }
 
   if (isLoading) {
     return <OverflowMenuItem itemText={t('loading', 'Loading...')} />;

--- a/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.resource.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.resource.tsx
@@ -23,7 +23,7 @@ export const useTestOrderBillStatus = (orderUuid: string, patientUuid: string) =
 };
 
 export const usePatientQueue = (patientUuid: string) => {
-  const config = useConfig({ externalModuleName: '@openmrs/esm-service-queues-app' });
+  const config = useConfig({ externalModuleName: '@kenyaemr/esm-service-queues-app' });
   const url = `${restBaseUrl}/visit-queue-entry?patient=${patientUuid}`;
   const { data, isLoading, error } = useSWR<{
     data: { results: Array<QueueEntry> };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

The root cause of this is moving from `@openmrs` to `@kenyaemr` module for queue management. This resulted in the `usePatientQueues` to fail silently.  In addition to this fix, i have also disable picking up lab order if fulfiller status is `IN_PROGRESS`


## Screenshots
https://github.com/palladiumkenya/kenyaemr-esm-3.x/assets/28008754/b8a14a2e-9dd2-45f1-bf7a-579443e7ed41

## Related Issue
https://github.com/palladiumkenya/openmrs-config-kenyaemr/pull/643


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
