### PR TITLE
Fix (tests) broken 'e2e' tests.

### DIFF
--- a/e2e/core/location-selector.ts
+++ b/e2e/core/location-selector.ts
@@ -3,8 +3,6 @@ import { Page } from '@playwright/test';
 export function addURLChangeListener(page: Page) {
   page.on('framenavigated', async (frame) => {
     if (frame === page.mainFrame()) {
-      // eslint-disable-next-line no-console
-      console.log('Navigated to URL:', frame.url());
       const currentURL = frame.url();
 
       if (currentURL.includes('/login/location')) {

--- a/e2e/core/location-selector.ts
+++ b/e2e/core/location-selector.ts
@@ -1,0 +1,17 @@
+import { Page } from '@playwright/test';
+
+export function addURLChangeListener(page: Page) {
+  page.on('framenavigated', async (frame) => {
+    if (frame === page.mainFrame()) {
+      // eslint-disable-next-line no-console
+      console.log('Navigated to URL:', frame.url());
+      const currentURL = frame.url();
+
+      if (currentURL.includes('/login/location')) {
+        const firstCheckbox = page.locator('input[type="radio"]').first();
+        await firstCheckbox.check({ force: true });
+        await page.locator('button:has-text("Confirm")').click();
+      }
+    }
+  });
+}

--- a/e2e/core/test.ts
+++ b/e2e/core/test.ts
@@ -1,5 +1,6 @@
 import { APIRequestContext, Page, test as base } from '@playwright/test';
 import { api } from '../fixtures';
+import { addURLChangeListener } from './location-selector';
 
 // This file sets up our custom test harness using the custom fixtures.
 // See https://playwright.dev/docs/test-fixtures#creating-a-fixture for details.
@@ -17,4 +18,8 @@ export interface CustomWorkerFixtures {
 
 export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
   api: [api, { scope: 'worker' }],
+  page: async ({ page }, use) => {
+    addURLChangeListener(page);
+    await use(page);
+  },
 });

--- a/e2e/pages/billing-page.ts
+++ b/e2e/pages/billing-page.ts
@@ -1,0 +1,9 @@
+import { Page } from '@playwright/test';
+
+export class BillingPage {
+  constructor(readonly page: Page) {}
+
+  async gotoBilling() {
+    await this.page.goto('/openmrs/spa/home/billing');
+  }
+}

--- a/e2e/pages/home-page.ts
+++ b/e2e/pages/home-page.ts
@@ -6,6 +6,14 @@ export class HomePage {
   async gotoHome() {
     await this.page.goto('home');
   }
+
+  async selectLocationIfPresent() {
+    if (await this.page.locator('text=Select your location from the list below.').isVisible()) {
+      const firstCheckbox = this.page.locator('input[type="radio"]').first();
+      await firstCheckbox.check();
+      await this.page.locator('button:has-text("Confirm")').click();
+    }
+  }
 }
 
 export class BillingPage {

--- a/e2e/pages/home-page.ts
+++ b/e2e/pages/home-page.ts
@@ -6,19 +6,4 @@ export class HomePage {
   async gotoHome() {
     await this.page.goto('home');
   }
-
-  async selectLocationIfPresent() {
-    if (await this.page.locator('text=Select your location from the list below.').isVisible()) {
-      const firstCheckbox = this.page.locator('input[type="radio"]').first();
-      await firstCheckbox.check();
-      await this.page.locator('button:has-text("Confirm")').click();
-    }
-  }
-}
-
-export class BillingPage {
-  constructor(readonly page: Page) {}
-  async gotoBilling() {
-    await this.page.goto('/openmrs/spa/home/billing');
-  }
 }

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,1 +1,2 @@
 export * from './home-page';
+export * from './billing-page';

--- a/e2e/specs/billing/billling-history.spec.ts
+++ b/e2e/specs/billing/billling-history.spec.ts
@@ -1,14 +1,15 @@
 import { test } from '../../core';
 import { expect } from '@playwright/test';
 import { HomePage, BillingPage } from '../../pages';
-import { billingForm } from '@kenyaemr/esm-billing-app';
 
-test('Accessing the Billing page Dashboard from Home', async ({ page }) => {
+test('Accessing the Billing page dashboard from home', async ({ page }) => {
   const homePage = new HomePage(page);
 
   await test.step('When I visit the home page', async () => {
     await homePage.gotoHome();
+    await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
   });
+
   await test.step('Then should be able to navigate to billing page', async () => {
     await page.getByRole('link', { name: 'Billing' }).click();
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home/billing`);
@@ -20,32 +21,36 @@ test('Accessing the Billing page Dashboard from Home', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Paid Bills' })).toBeVisible();
   });
 });
+
 test('Check if Bill table is available', async ({ page }) => {
   const billingPage = new BillingPage(page);
-  await test.step('When I visit Billing dashboard', async () => {
-    await billingPage.gotoBilling();
-  });
 
-  await test.step('Then should be at the home page', async () => {
+  await test.step('When I visit billing dashboard, I should be at the billing page', async () => {
+    await billingPage.gotoBilling();
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home/billing`);
   });
-  await test.step('Then I  should be able to see Bill table', async () => {
+
+  await test.step('Then i should be able to see bills table', async () => {
     const billList = page
       .locator('div[class*="-esm-billing__bills"] h4')
       .filter({ hasText: /^Bill list$/ })
       .first();
     await expect(billList).toBeVisible();
   });
+
   await test.step('I should be able  to  see table header ', async () => {
     const billHeaders = page.locator('div[class*="-esm-billing__bills"] tr').first();
     await expect(billHeaders).toContainText('Visit timeIdentifierNameBilled Items');
   });
 });
+
 test('Make payment for a bill', async ({ page }) => {
   const billingPage = new BillingPage(page);
-  await test.step('When I visit Billing dashboard', async () => {
+
+  await test.step('When I visit billing dashboard', async () => {
     await billingPage.gotoBilling();
   });
+
   await test.step('when I click a on a client on table I should be directed to patient bill summary', async () => {
     const tdWithAnchorTags = await page.$$('div[class*="-esm-billing__bills"] tbody td a');
     if (tdWithAnchorTags.length <= 0) {

--- a/e2e/specs/login-test.spec.ts
+++ b/e2e/specs/login-test.spec.ts
@@ -7,13 +7,6 @@ test('Go to homepage', async ({ page }) => {
 
   await test.step('When I visit the home page', async () => {
     await homePage.gotoHome();
-  });
-
-  await test.step('If redirected to select login location, choose location', async () => {
-    await homePage.selectLocationIfPresent();
-  });
-
-  await test.step('Then should be at the home page', async () => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
   });
 });

--- a/e2e/specs/login-test.spec.ts
+++ b/e2e/specs/login-test.spec.ts
@@ -9,6 +9,10 @@ test('Go to homepage', async ({ page }) => {
     await homePage.gotoHome();
   });
 
+  await test.step('If redirected to select login location, choose location', async () => {
+    await homePage.selectLocationIfPresent();
+  });
+
   await test.step('Then should be at the home page', async () => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
   });


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Since I started working on this project I have noticed a recurring failing tests in most pull requests. I investigated the cause of issue was that the tests did not account for when playwright is redirected to the **select login location page**. In this PR I have fixed the issue by adding a global event listener that listens when the page changes to the aforementioned one and automatically selects the first login location and logs inthe test client.

This playwright client kept failing with errors such as 
```
Error: Timed out 40000ms waiting for expect(received).toHaveURL(expected)

    Expected string: "https://dev.kenyahmis.org/openmrs/spa/home"
    Received string: "https://dev.kenyahmis.org/openmrs/spa/login/location"
```
The reason why the playwright client timed out is because it was looking for the correct element in the wrong page. This PR hopefully fixes this. I have tested the new test suite locally using `yarn playwright test` and everything seems fine now. However I have not tested in an action context since i couldn`t figure out how to run Github Actions on a forked repo. I doubt that it will fail on github runners if it works in my 7 year old HP probook.


## Screenshots
![image](https://github.com/user-attachments/assets/85b1df69-1920-49b4-942b-25dcf9720a07)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
