### PR TITLE
fix (tests) : broken e2e tests to handle no bills cases

### DIFF
--- a/e2e/specs/billing/billling-history.spec.ts
+++ b/e2e/specs/billing/billling-history.spec.ts
@@ -36,7 +36,7 @@ test('Check if Bill table is available', async ({ page }) => {
       .filter({ hasText: /^Bill list$/ })
       .first();
 
-    await billListLocator.waitFor({ state: 'visible', timeout: 40000 });
+    await page.waitForTimeout(40000);
 
     const billListTableCount = await billListLocator.count();
 
@@ -64,7 +64,7 @@ test('Make payment for a bill', async ({ page }) => {
     .filter({ hasText: /^Bill list$/ })
     .first();
 
-  await billListLocator.waitFor({ state: 'visible', timeout: 40000 });
+  await page.waitForTimeout(40000);
 
   const billListTableCount = await billListLocator.count();
 

--- a/e2e/specs/billing/billling-history.spec.ts
+++ b/e2e/specs/billing/billling-history.spec.ts
@@ -30,17 +30,25 @@ test('Check if Bill table is available', async ({ page }) => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home/billing`);
   });
 
-  await test.step('Then i should be able to see bills table', async () => {
-    const billList = page
+  await test.step('Then I should be able to see bills table if there are bills', async () => {
+    const billListLocator = page
       .locator('div[class*="-esm-billing__bills"] h4')
       .filter({ hasText: /^Bill list$/ })
       .first();
-    await expect(billList).toBeVisible();
-  });
 
-  await test.step('I should be able  to  see table header ', async () => {
-    const billHeaders = page.locator('div[class*="-esm-billing__bills"] tr').first();
-    await expect(billHeaders).toContainText('Visit timeIdentifierNameBilled Items');
+    await billListLocator.waitFor({ state: 'visible', timeout: 40000 });
+
+    const billListTableCount = await billListLocator.count();
+
+    if (billListTableCount > 0) {
+      await expect(billListLocator).toBeVisible();
+      await test.step('I should be able to see table header', async () => {
+        const billHeaders = page.locator('div[class*="-esm-billing__bills"] tr').first();
+        await expect(billHeaders).toContainText('Visit timeIdentifierNameBilled Items');
+      });
+    } else {
+      test.skip();
+    }
   });
 });
 
@@ -51,13 +59,27 @@ test('Make payment for a bill', async ({ page }) => {
     await billingPage.gotoBilling();
   });
 
-  await test.step('when I click a on a client on table I should be directed to patient bill summary', async () => {
-    const tdWithAnchorTags = await page.$$('div[class*="-esm-billing__bills"] tbody td a');
-    if (tdWithAnchorTags.length <= 0) {
-      return;
-    }
-    const randomIndex = Math.floor(Math.random() * tdWithAnchorTags.length);
-    await tdWithAnchorTags[randomIndex].click();
-    await expect(page).toHaveURL('^/spa/home/billing/patient/');
-  });
+  const billListLocator = page
+    .locator('div[class*="-esm-billing__bills"] h4')
+    .filter({ hasText: /^Bill list$/ })
+    .first();
+
+  await billListLocator.waitFor({ state: 'visible', timeout: 40000 });
+
+  const billListTableCount = await billListLocator.count();
+
+  if (billListTableCount > 0) {
+    await test.step('when I click a on a client on table I should be directed to patient bill summary', async () => {
+      const tdWithAnchorTags = await page.$$('div[class*="-esm-billing__bills"] tbody td a');
+      if (tdWithAnchorTags.length <= 0) {
+        return;
+      }
+      const randomIndex = Math.floor(Math.random() * tdWithAnchorTags.length);
+      await tdWithAnchorTags[randomIndex].click();
+      const currentURL = page.url();
+      expect(currentURL).toContain('/spa/home/billing/patient/');
+    });
+  } else {
+    test.skip();
+  }
 });


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Yesterday evening I opened this PR #284 . Yeah whilst I thought I had addressed all the issues I was surprised to still notice failing e2e tests this morning. This prompted an investigation and I found out an edge case that I and the person who had originally written the test had overlooked. The tests for accessing and manipulating the billing table only passed If the bills table existed. Since those elements are conditionally rendered on the app if there are no bills the tests fail.

Funny enough thats why my tests passed yesterday since playwright runs against the dev environment which there is almost a 100% certainty there will be bills in the evenings haha.

In this PR I have updated the tests to check for the availability of the rendered bills table and thereby proceed with the tests otherwise if the tests run in the morning and there are no biills It should skip the tests. Attached below is a playwright video for a failing test.

## Screenshots
[212906403340d05d0541f4dc14cca68bf5257729.webm](https://github.com/user-attachments/assets/7b425462-3012-4c53-85aa-1ca211d725ff)


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
