### PR TITLE
Khp3 6301 add ability to add multiple orders to the lab manifest

### DIFF
--- a/packages/esm-lab-manifest-app/src/config-schema.ts
+++ b/packages/esm-lab-manifest-app/src/config-schema.ts
@@ -10,7 +10,7 @@ export const configSchema = {
         type: 'EID Type',
       },
       {
-        id: 1,
+        id: 2,
         type: 'VL Type',
       },
       {

--- a/packages/esm-lab-manifest-app/src/config-schema.ts
+++ b/packages/esm-lab-manifest-app/src/config-schema.ts
@@ -1,5 +1,25 @@
 import { Type, validator } from '@openmrs/esm-framework';
 
-export const configSchema = {};
-
-export type Config = {};
+export const configSchema = {
+  labmanifestTypes: {
+    _type: Type.Array,
+    _description: 'List of Lab manifest types',
+    _default: [
+      {
+        id: 1,
+        type: 'EID Type',
+      },
+      {
+        id: 1,
+        type: 'VL Type',
+      },
+      {
+        id: 3,
+        type: 'FLU Type',
+      },
+    ],
+  },
+};
+export interface LabManifestConfig {
+  labmanifestTypes: Array<{ id: number; type: string }>;
+}

--- a/packages/esm-lab-manifest-app/src/forms/lab-manifest-form.scss
+++ b/packages/esm-lab-manifest-app/src/forms/lab-manifest-form.scss
@@ -15,7 +15,7 @@
   display: flex;
   justify-content: space-between;
   .warning {
-    @include type.type-style('heading-compact-01');
+    @include type.type-style('heading-01');
     color: $ui-05;
   }
 }
@@ -46,10 +46,11 @@
   flex-wrap: nowrap;
   gap: spacing.$spacing-05; // Adjust gap between columns
   align-items: center;
+  width: 100%;
 }
 
 .datePickerInput {
-  width: 100%;
+  flex-grow: 1;
 }
 
 .button {
@@ -64,16 +65,23 @@
   padding: 0rem;
   margin-top: spacing.$spacing-05;
   display: flex;
-  justify-content: flex-end;
-  gap: spacing.$spacing-05;
+  justify-content: space-between;
+  width: 100%;
   margin-bottom: spacing.$spacing-05;
+}
+
+.datesContainer {
+  padding: 0rem;
+  justify-content: space-between;
+  width: 100%;
+  display: flex;
 }
 .inlineActions {
   display: flex;
   gap: spacing.$spacing-05; /* Adjust the spacing as needed */
 }
 
-.contactFormTitle {
+.formTitle {
   @include type.type-style('heading-02');
   display: flex;
   align-items: center;
@@ -112,15 +120,4 @@
     justify-content: flex-end;
     gap: spacing.$spacing-05;
   }
-}
-
-/* New Styles for Facility and Visit Type */
-.facilityVisitRow {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: spacing.$spacing-05; /* Adjust gap between columns */
-}
-
-.facilityColumn {
-  flex: 1 1 0%; /* Makes columns take up equal space */
 }

--- a/packages/esm-lab-manifest-app/src/forms/lab-manifest-form.workspace.tsx
+++ b/packages/esm-lab-manifest-app/src/forms/lab-manifest-form.workspace.tsx
@@ -10,15 +10,16 @@ import {
   TextInput,
 } from '@carbon/react';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { DefaultWorkspaceProps, parseDate, showSnackbar, useLayoutType } from '@openmrs/esm-framework';
+import { DefaultWorkspaceProps, parseDate, showSnackbar, useConfig, useLayoutType } from '@openmrs/esm-framework';
 import React, { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
-import { LabManifestFilters, labManifestFormSchema, manifestTypes, saveLabManifest } from '../lab-manifest.resources';
+import { LabManifestFilters, labManifestFormSchema, saveLabManifest } from '../lab-manifest.resources';
 import styles from './lab-manifest-form.scss';
 import { County, MappedLabManifest } from '../types';
 import { mutate } from 'swr';
+import { LabManifestConfig } from '../config-schema';
 interface LabManifestFormProps extends DefaultWorkspaceProps {
   patientUuid: string;
   manifest?: MappedLabManifest;
@@ -27,10 +28,12 @@ interface LabManifestFormProps extends DefaultWorkspaceProps {
 type ContactListFormType = z.infer<typeof labManifestFormSchema>;
 
 const LabManifestForm: React.FC<LabManifestFormProps> = ({ closeWorkspace, manifest }) => {
+  const { labmanifestTypes } = useConfig<LabManifestConfig>();
   const counties = require('../counties.json') as County[];
   const form = useForm<ContactListFormType>({
     defaultValues: {
       ...manifest,
+      manifestType: manifest?.manifestType ? Number(manifest.manifestType) : undefined,
       dispatchDate: manifest?.dispatchDate ? parseDate(manifest.dispatchDate) : undefined,
       startDate: manifest?.startDate ? parseDate(manifest.startDate) : undefined,
       endDate: manifest?.endDate ? parseDate(manifest.endDate) : undefined,
@@ -129,8 +132,8 @@ const LabManifestForm: React.FC<LabManifestFormProps> = ({ closeWorkspace, manif
                 }}
                 initialSelectedItem={field.value}
                 label="Choose option"
-                items={manifestTypes.map((r) => r.value)}
-                itemToString={(item) => manifestTypes.find((r) => r.value === item)?.label ?? ''}
+                items={labmanifestTypes.map((r) => r.id)}
+                itemToString={(item) => labmanifestTypes.find((r) => r.id === item)?.type ?? ''}
               />
             )}
           />

--- a/packages/esm-lab-manifest-app/src/forms/lab-manifest-orders-to-manifest.modal.tsx
+++ b/packages/esm-lab-manifest-app/src/forms/lab-manifest-orders-to-manifest.modal.tsx
@@ -1,0 +1,168 @@
+import {
+  Button,
+  ButtonSet,
+  Column,
+  DatePicker,
+  DatePickerInput,
+  Dropdown,
+  Form,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Row,
+  Stack,
+} from '@carbon/react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { showSnackbar } from '@openmrs/esm-framework';
+import React from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { mutate } from 'swr';
+import { z } from 'zod';
+import { addOrderToManifest, labManifestOrderToManifestFormSchema, sampleTypes } from '../lab-manifest.resources';
+import styles from './lab-manifest-form.scss';
+
+interface LabManifestOrdersToManifestFormProps {
+  onClose: () => void;
+  props: {
+    title?: string;
+    selectedOrders: Array<{
+      labManifest: {
+        uuid: string;
+      };
+      order: {
+        uuid: string;
+      };
+      payload: string;
+    }>;
+  };
+}
+
+type OrderToManifestFormType = z.infer<typeof labManifestOrderToManifestFormSchema>;
+
+const LabManifestOrdersToManifestForm: React.FC<LabManifestOrdersToManifestFormProps> = ({
+  onClose,
+  props: { title, selectedOrders },
+}) => {
+  const { t } = useTranslation();
+  const form = useForm<OrderToManifestFormType>({
+    defaultValues: {},
+    resolver: zodResolver(labManifestOrderToManifestFormSchema),
+  });
+
+  const onSubmit = async (values: OrderToManifestFormType) => {
+    try {
+      const results = await Promise.allSettled(
+        selectedOrders.map((order) => addOrderToManifest({ ...order, ...values })),
+      );
+      results.forEach((res) => {
+        if (res.status === 'fulfilled') {
+          showSnackbar({ title: 'Success', kind: 'success', subtitle: JSON.stringify(res.value) });
+        } else {
+          showSnackbar({ title: 'Success', kind: 'error', subtitle: JSON.stringify(res.reason) });
+        }
+      });
+      mutate((key) => {
+        return typeof key === 'string' && key.startsWith(`/ws/rest/v1/labmanifest?status`);
+      });
+      onClose();
+      showSnackbar({ title: 'Success', kind: 'success', subtitle: 'Lab manifest created successfully!' });
+    } catch (error) {
+      showSnackbar({ title: 'Failure', kind: 'error', subtitle: 'Error adding orders to the manifest' });
+    }
+  };
+
+  return (
+    <React.Fragment>
+      <Form onSubmit={form.handleSubmit(onSubmit)}>
+        <ModalHeader closeModal={onClose} className={styles.heading}>
+          {title ?? t('updateSampleDetails', 'Update Sample Details')}
+        </ModalHeader>
+        <ModalBody>
+          <Stack gap={4} className={styles.grid}>
+            <Column>
+              <Controller
+                control={form.control}
+                name="sampleType"
+                render={({ field }) => (
+                  <Dropdown
+                    ref={field.ref}
+                    invalid={form.formState.errors[field.name]?.message}
+                    invalidText={form.formState.errors[field.name]?.message}
+                    id="manifestType"
+                    titleText={t('sampleType', 'Sample Type')}
+                    onChange={(e) => {
+                      field.onChange(e.selectedItem);
+                    }}
+                    initialSelectedItem={field.value}
+                    label="Choose option"
+                    items={sampleTypes.map((r) => r.value)}
+                    itemToString={(item) => sampleTypes.find((r) => r.value === item)?.label ?? ''}
+                  />
+                )}
+              />
+            </Column>
+            <Row className={styles.datePickersRow}>
+              <Column className={styles.datePickerInput}>
+                <Controller
+                  control={form.control}
+                  name="sampleCollectionDate"
+                  render={({ field }) => (
+                    <DatePicker
+                      dateFormat="d/m/Y"
+                      id="sampleCollectionDate"
+                      datePickerType="single"
+                      {...field}
+                      invalid={form.formState.errors[field.name]?.message}
+                      invalidText={form.formState.errors[field.name]?.message}>
+                      <DatePickerInput
+                        invalid={form.formState.errors[field.name]?.message}
+                        invalidText={form.formState.errors[field.name]?.message}
+                        placeholder="mm/dd/yyyy"
+                        labelText={t('sampleCollectionDate', 'Sample collection date')}
+                      />
+                    </DatePicker>
+                  )}
+                />
+              </Column>
+              <Column className={styles.datePickerInput}>
+                <Controller
+                  control={form.control}
+                  name="sampleSeparationDate"
+                  render={({ field }) => (
+                    <DatePicker
+                      dateFormat="d/m/Y"
+                      id="sampleSeparationDate"
+                      datePickerType="single"
+                      {...field}
+                      invalid={form.formState.errors[field.name]?.message}
+                      invalidText={form.formState.errors[field.name]?.message}>
+                      <DatePickerInput
+                        invalid={form.formState.errors[field.name]?.message}
+                        invalidText={form.formState.errors[field.name]?.message}
+                        placeholder="mm/dd/yyyy"
+                        labelText={t('sampleSeparationDate', 'Sample seperation date')}
+                      />
+                    </DatePicker>
+                  )}
+                />
+              </Column>
+            </Row>
+          </Stack>
+        </ModalBody>
+        <ModalFooter>
+          <ButtonSet className={styles.buttonSet}>
+            <Button className={styles.button} kind="primary" disabled={form.formState.isSubmitting} type="submit">
+              Submit
+            </Button>
+            <Button className={styles.button} kind="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+          </ButtonSet>
+        </ModalFooter>
+      </Form>
+    </React.Fragment>
+  );
+};
+
+export default LabManifestOrdersToManifestForm;

--- a/packages/esm-lab-manifest-app/src/forms/sample-delete-confirm-dialog.modal.tsx
+++ b/packages/esm-lab-manifest-app/src/forms/sample-delete-confirm-dialog.modal.tsx
@@ -1,0 +1,30 @@
+import { Button, ButtonSet, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface SampleDeleteConfirmDialogProps {
+  onClose: () => void;
+  onDelete: () => void;
+}
+const SampleDeleteConfirmDialog: React.FC<SampleDeleteConfirmDialogProps> = ({ onClose, onDelete }) => {
+  const { t } = useTranslation();
+
+  return (
+    <React.Fragment>
+      <ModalHeader closeModal={onClose}>{t('warning', 'Warning!')}</ModalHeader>
+      <ModalBody>Are you sure you want to delete sample.This action is irriversible?</ModalBody>
+      <ModalFooter>
+        <ButtonSet>
+          <Button kind="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button kind="primary" onClick={onDelete}>
+            Remove
+          </Button>
+        </ButtonSet>
+      </ModalFooter>
+    </React.Fragment>
+  );
+};
+
+export default SampleDeleteConfirmDialog;

--- a/packages/esm-lab-manifest-app/src/hooks/useActiveRequests.ts
+++ b/packages/esm-lab-manifest-app/src/hooks/useActiveRequests.ts
@@ -1,24 +1,15 @@
-import { restBaseUrl } from '@openmrs/esm-framework';
+import { FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 import { activeRequests } from '../lab-manifest.mock';
 import { ActiveRequests } from '../types';
 
-const mockeFetch = async (url: string) => {
-  const status = url.split('=').at(-1);
-  return await new Promise<Array<ActiveRequests>>((resolve, _) => {
-    setTimeout(() => {
-      resolve(activeRequests);
-    }, 3000);
-  });
-};
-
-const useActiveRequests = () => {
-  const url = `${restBaseUrl}/active-request`;
-  const { isLoading, error, data } = useSWR<Array<ActiveRequests>>(url, mockeFetch);
+const useActiveRequests = (labManifestUuid: string) => {
+  const url = `${restBaseUrl}/kemrorder/validorders?manifestUuid=${labManifestUuid}`;
+  const { isLoading, error, data } = useSWR<FetchResponse<ActiveRequests>>(url, openmrsFetch);
 
   return {
     isLoading,
-    requests: data ?? [],
+    request: data?.data,
     error,
   };
 };

--- a/packages/esm-lab-manifest-app/src/index.ts
+++ b/packages/esm-lab-manifest-app/src/index.ts
@@ -30,7 +30,10 @@ export const labManifestOrderToManifestForm = getAsyncLifecycle(
   () => import('./forms/lab-manifest-orders-to-manifest.modal'),
   options,
 );
-
+export const sampleDeleteConfirmDialog = getAsyncLifecycle(
+  () => import('./forms/sample-delete-confirm-dialog.modal'),
+  options,
+);
 export const labManifestDashboardLink = getSyncLifecycle(
   createLeftPanelLink({
     name: 'lab-manifest',

--- a/packages/esm-lab-manifest-app/src/index.ts
+++ b/packages/esm-lab-manifest-app/src/index.ts
@@ -26,6 +26,10 @@ export function startupApp() {
 
 export const root = getAsyncLifecycle(() => import('./root.component'), options);
 export const labManifestForm = getAsyncLifecycle(() => import('./forms/lab-manifest-form.workspace'), options);
+export const labManifestOrderToManifestForm = getAsyncLifecycle(
+  () => import('./forms/lab-manifest-orders-to-manifest.modal'),
+  options,
+);
 
 export const labManifestDashboardLink = getSyncLifecycle(
   createLeftPanelLink({

--- a/packages/esm-lab-manifest-app/src/lab-manifest.resources.ts
+++ b/packages/esm-lab-manifest-app/src/lab-manifest.resources.ts
@@ -45,7 +45,7 @@ const PHONE_NUMBER_REGEX = /^(\+?254|0)((7|1)\d{8})$/;
 export const labManifestFormSchema = z.object({
   startDate: z.date({ coerce: true }),
   endDate: z.date({ coerce: true }),
-  manifestType: z.string(),
+  manifestType: z.number({ coerce: true }),
   dispatchDate: z.date({ coerce: true }),
   courierName: z.string().optional(),
   personHandedTo: z.string().optional(),
@@ -58,13 +58,6 @@ export const labManifestFormSchema = z.object({
   labPersonContact: z.string().regex(PHONE_NUMBER_REGEX, { message: 'Invalid phone number' }),
   manifestStatus: z.string(),
 });
-
-export const manifestTypes = [
-  {
-    value: 'VL',
-    label: 'Viral load',
-  },
-];
 
 export const saveLabManifest = async (data: z.infer<typeof labManifestFormSchema>, manifestId: string | undefined) => {
   let url;
@@ -81,7 +74,22 @@ export const saveLabManifest = async (data: z.infer<typeof labManifestFormSchema
       'Content-Type': 'application/json',
     },
     method: 'POST',
-    body: JSON.stringify(data),
+    body: JSON.stringify({
+      startDate: data.startDate,
+      endDate: data.endDate,
+      dispatchDate: data.dispatchDate,
+      courier: data.courierName,
+      courierOfficer: data.personHandedTo,
+      status: data.manifestStatus,
+      county: data.county,
+      subCounty: data.subCounty,
+      facilityEmail: data.facilityEmail,
+      facilityPhoneContact: data.facilityPhoneContact,
+      clinicianPhoneContact: data.clinicianContact,
+      clinicianName: data.clinicianName,
+      labPocPhoneNumber: data.labPersonContact,
+      manifestType: data.manifestType,
+    }),
     signal: abortController.signal,
   });
 };

--- a/packages/esm-lab-manifest-app/src/lab-manifest.resources.ts
+++ b/packages/esm-lab-manifest-app/src/lab-manifest.resources.ts
@@ -1,4 +1,4 @@
-import { generateOfflineUuid, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import { z } from 'zod';
 import { LabManifest, MappedLabManifest } from './types';
 
@@ -114,6 +114,15 @@ export const addOrderToManifest = async (data: z.infer<typeof labManifestOrderTo
     },
     method: 'POST',
     body: JSON.stringify({ ...data, status: 'Pending' }),
+    signal: abortController.signal,
+  });
+};
+
+export const removeSampleFromTheManifest = async (orderUuid: string) => {
+  let url = `${restBaseUrl}/labmanifestorder/${orderUuid}`;
+  const abortController = new AbortController();
+  return openmrsFetch(url, {
+    method: 'DELETE',
     signal: abortController.signal,
   });
 };

--- a/packages/esm-lab-manifest-app/src/routes.json
+++ b/packages/esm-lab-manifest-app/src/routes.json
@@ -23,6 +23,10 @@
       "component": "labManifestOrderToManifestForm"
     },
     {
+      "name": "sample-delete-confirm-dialog",
+      "component": "sampleDeleteConfirmDialog"
+    },
+    {
       "component": "root",
       "name": "lab-manifest-dashboard-root",
       "slot": "lab-manifest-dashboard-slot"

--- a/packages/esm-lab-manifest-app/src/routes.json
+++ b/packages/esm-lab-manifest-app/src/routes.json
@@ -19,6 +19,10 @@
       "component": "labManifestForm"
     },
     {
+      "name": "lab-manifest-order-modal-form",
+      "component": "labManifestOrderToManifestForm"
+    },
+    {
       "component": "root",
       "name": "lab-manifest-dashboard-root",
       "slot": "lab-manifest-dashboard-slot"

--- a/packages/esm-lab-manifest-app/src/tables/lab-manifest-active-requests.component.tsx
+++ b/packages/esm-lab-manifest-app/src/tables/lab-manifest-active-requests.component.tsx
@@ -10,61 +10,41 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableSelectAll,
+  TableSelectRow,
 } from '@carbon/react';
-import { View } from '@carbon/react/icons';
-import { ErrorState, navigate, useLayoutType, usePagination } from '@openmrs/esm-framework';
+import { Add } from '@carbon/react/icons';
+import { ErrorState, showModal, usePagination } from '@openmrs/esm-framework';
 import { CardHeader, EmptyState, usePaginationInfo } from '@openmrs/esm-patient-common-lib';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import styles from './lab-manifest-table.scss';
 import useActiveRequests from '../hooks/useActiveRequests';
-import { ActiveRequests } from '../types';
+import styles from './lab-manifest-table.scss';
 
 interface LabManifestActiveRequestsProps {
   manifestUuid: string;
 }
 
 const LabManifestActiveRequests: React.FC<LabManifestActiveRequestsProps> = ({ manifestUuid }) => {
-  const { error, isLoading, requests } = useActiveRequests();
+  const { error, isLoading, request: request } = useActiveRequests(manifestUuid);
 
   const { t } = useTranslation();
   const [pageSize, setPageSize] = useState(10);
   const headerTitle = t('activeRequests', 'Active Requests');
-  const { results, totalPages, currentPage, goTo } = usePagination(requests, pageSize);
+  const { results, totalPages, currentPage, goTo } = usePagination(request?.Orders ?? [], pageSize);
   const { pageSizes } = usePaginationInfo(pageSize, totalPages, currentPage, results.length);
-
   const headers = [
     {
       header: t('patientName', 'Patient name'),
-      key: 'startDate',
+      key: 'patientName',
     },
     {
       header: t('cccKDODNumber', 'CCC/KDOD Number'),
-      key: 'cccKDODNumber',
+      key: 'cccKdod',
     },
     {
-      header: t('batchNumber', 'Batch Number'),
-      key: 'batchNumber',
-    },
-    {
-      header: t('sampleType', 'Sample type'),
-      key: 'sampleType',
-    },
-    {
-      header: t('manifestId', 'Manifest Id'),
-      key: 'manifestId',
-    },
-    {
-      header: t('labPersonContact', 'Lab person Contact'),
-      key: 'labPersonContact',
-    },
-    {
-      header: t('status', 'Status'),
-      key: 'status',
-    },
-    {
-      header: t('dispatch', 'Dispatch'),
-      key: 'dispatch',
+      header: t('dateRequested', 'Date Requested'),
+      key: 'dateRequested',
     },
     {
       header: t('actions', 'Actions'),
@@ -72,22 +52,52 @@ const LabManifestActiveRequests: React.FC<LabManifestActiveRequestsProps> = ({ m
     },
   ];
 
-  const handleViewManifestSamples = (manifestUuid: string) => {
-    navigate({ to: window.getOpenmrsSpaBase() + `home/lab-manifest/${manifestUuid}` });
+  const handleAddSelectedToManifest = (
+    selected: Array<{
+      labManifest: {
+        uuid: string;
+      };
+      order: {
+        uuid: string;
+      };
+      payload: string;
+    }>,
+  ) => {
+    const dispose = showModal('lab-manifest-order-modal-form', {
+      onClose: () => dispose(),
+      props: {
+        title: selected.length > 1 ? 'Add Multiple Orders To Manifest' : undefined,
+        selectedOrders: selected,
+      },
+    });
   };
 
   const tableRows =
-    (results as ActiveRequests[])?.map((activeRequest) => {
+    results?.map((activeRequest) => {
       return {
-        id: `${activeRequest.uuid}`,
+        id: `${activeRequest.orderUuid}`,
+        patientName: activeRequest.patientName,
+        cccKdod: activeRequest.cccKdod,
+        dateRequested: activeRequest.dateRequested,
         actions: (
           <Button
-            renderIcon={View}
-            hasIconOnly
             kind="tertiary"
-            iconDescription={t('view', 'View')}
-            onClick={() => handleViewManifestSamples(activeRequest.uuid)}
-          />
+            iconDescription={t('addToManifest', 'Add To manifest')}
+            onClick={() =>
+              handleAddSelectedToManifest([
+                {
+                  labManifest: {
+                    uuid: manifestUuid,
+                  },
+                  order: {
+                    uuid: activeRequest.orderUuid,
+                  },
+                  payload: activeRequest.payload,
+                },
+              ])
+            }>
+            Add To manifest
+          </Button>
         ),
       };
     }) ?? [];
@@ -99,7 +109,7 @@ const LabManifestActiveRequests: React.FC<LabManifestActiveRequestsProps> = ({ m
     return <ErrorState headerTitle={headerTitle} error={error} />;
   }
 
-  if (requests.length === 0) {
+  if ((request?.Orders ?? []).length === 0) {
     return (
       <EmptyState
         headerTitle={t('activeRequests', 'Active Requests')}
@@ -109,46 +119,75 @@ const LabManifestActiveRequests: React.FC<LabManifestActiveRequestsProps> = ({ m
   }
   return (
     <div className={styles.widgetContainer}>
-      <CardHeader title={headerTitle}>{''}</CardHeader>
       <DataTable
         useZebraStyles
         size="sm"
         rows={tableRows ?? []}
         headers={headers}
-        render={({ rows, headers, getHeaderProps, getTableProps, getTableContainerProps }) => (
-          <TableContainer {...getTableContainerProps()}>
-            <Table {...getTableProps()}>
-              <TableHead>
-                <TableRow>
-                  {headers.map((header) => (
-                    <TableHeader
-                      {...getHeaderProps({
-                        header,
-                        isSortable: header.isSortable,
-                      })}>
-                      {header.header?.content ?? header.header}
-                    </TableHeader>
-                  ))}
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {rows.map((row) => (
-                  <TableRow key={row.id}>
-                    {row.cells.map((cell) => (
-                      <TableCell key={cell.id}>{cell.value}</TableCell>
+        render={({
+          rows,
+          headers,
+          getHeaderProps,
+          getRowProps,
+          getSelectionProps,
+          getTableProps,
+          getTableContainerProps,
+          selectedRows,
+        }) => (
+          <>
+            <CardHeader title={headerTitle}>
+              <Button
+                onClick={() => {
+                  const data = selectedRows.map(({ id }) => ({
+                    labManifest: {
+                      uuid: manifestUuid,
+                    },
+                    order: {
+                      uuid: id,
+                    },
+                    payload: request.Orders.find(({ orderUuid }) => orderUuid === id)?.payload ?? '',
+                  }));
+
+                  handleAddSelectedToManifest(data);
+                }}
+                renderIcon={Add}
+                kind="ghost">
+                {t('addSelectedSamples', 'Add Selected Samples')}
+              </Button>
+            </CardHeader>
+            <TableContainer {...getTableContainerProps()}>
+              <Table {...getTableProps()}>
+                <TableHead>
+                  <TableRow>
+                    <TableSelectAll {...getSelectionProps()} />
+                    {headers.map((header, i) => (
+                      <TableHeader key={i} {...getHeaderProps({ header })}>
+                        {header.header}
+                      </TableHeader>
                     ))}
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
+                </TableHead>
+                <TableBody>
+                  {rows.map((row, i) => (
+                    <TableRow key={i} {...getRowProps({ row })} onClick={(evt) => {}}>
+                      <TableSelectRow {...getSelectionProps({ row })} />
+                      {row.cells.map((cell) => (
+                        <TableCell key={cell.id}>{cell.value}</TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </>
         )}
       />
+
       <Pagination
         page={currentPage}
         pageSize={pageSize}
         pageSizes={pageSizes}
-        totalItems={requests.length}
+        totalItems={(request?.Orders ?? []).length}
         onChange={({ page, pageSize }) => {
           goTo(page);
           setPageSize(pageSize);

--- a/packages/esm-lab-manifest-app/src/tables/lab-manifest-active-requests.component.tsx
+++ b/packages/esm-lab-manifest-app/src/tables/lab-manifest-active-requests.component.tsx
@@ -63,13 +63,15 @@ const LabManifestActiveRequests: React.FC<LabManifestActiveRequestsProps> = ({ m
       payload: string;
     }>,
   ) => {
-    const dispose = showModal('lab-manifest-order-modal-form', {
-      onClose: () => dispose(),
-      props: {
-        title: selected.length > 1 ? 'Add Multiple Orders To Manifest' : undefined,
-        selectedOrders: selected,
-      },
-    });
+    if (selected.length > 0) {
+      const dispose = showModal('lab-manifest-order-modal-form', {
+        onClose: () => dispose(),
+        props: {
+          title: selected.length > 1 ? 'Add Multiple Orders To Manifest' : undefined,
+          selectedOrders: selected,
+        },
+      });
+    }
   };
 
   const tableRows =

--- a/packages/esm-lab-manifest-app/src/types/index.ts
+++ b/packages/esm-lab-manifest-app/src/types/index.ts
@@ -59,7 +59,19 @@ export interface LabManifestSample {
 }
 
 export interface ActiveRequests {
-  uuid: string;
+  Orders: Array<{
+    orderId: number;
+    orderUuid: string;
+    patientId: number;
+    patientUuid: string;
+    patientName: string;
+    cccKdod: string;
+    dateRequested: string;
+    payload: string;
+    hasProblem;
+  }>;
+  cccNumberType: number;
+  heiNumberType: number;
 }
 
 export interface Constiuency {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

https://thepalladiumgroup.atlassian.net/browse/KHP3-6301

## Summary
- Made valid orders table selectable
- Implemented modal dialog form for prompting addition sample information
- Removing sample from the manifest

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

<!--

https://github.com/user-attachments/assets/674a0973-eb57-4fee-ad53-7f93fbd2f5f9


https://github.com/user-attachments/assets/53ce7386-f647-472a-ab0b-a3bcd0672dbb


Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
