### PR TITLE
KHP3-6329: Restore Card Header Layout in Billing History Table

### DIFF
--- a/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
+++ b/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
@@ -26,6 +26,7 @@ import {
   usePaginationInfo,
   CardHeader,
   useLaunchWorkspaceRequiringVisit,
+  EmptyState,
 } from '@openmrs/esm-patient-common-lib';
 import { useBills } from '../billing.resource';
 import InvoiceTable from '../invoice/invoice-table.component';
@@ -103,24 +104,13 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
 
   if (bills.length === 0) {
     return (
-      <>
-        <div className={styles.widgetCard}>
-          <CardHeader title={t('patientBilling', 'Patient billing')}>
-            <></>
-          </CardHeader>
-        </div>
-        <Layer>
-          <Tile className={styles.tile}>
-            <div className={styles.illo}>
-              <EmptyDataIllustration />
-            </div>
-            <p className={styles.content}>There are no bills to display.</p>
-            <Button onClick={handleLaunchBillForm} kind="ghost">
-              {t('launchBillForm', 'Launch bill form')}
-            </Button>
-          </Tile>
-        </Layer>
-      </>
+      <Layer>
+        <EmptyState
+          displayText={''}
+          headerTitle={t('patientBilling', 'Patient billing')}
+          launchForm={handleLaunchBillForm}
+        />
+      </Layer>
     );
   }
 

--- a/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
+++ b/packages/esm-billing-app/src/bill-history/bill-history.component.tsx
@@ -104,9 +104,11 @@ const BillHistory: React.FC<BillHistoryProps> = ({ patientUuid }) => {
   if (bills.length === 0) {
     return (
       <>
-        <CardHeader title={t('patientBilling', 'Patient billing')}>
-          <></>
-        </CardHeader>
+        <div className={styles.widgetCard}>
+          <CardHeader title={t('patientBilling', 'Patient billing')}>
+            <></>
+          </CardHeader>
+        </div>
         <Layer>
           <Tile className={styles.tile}>
             <div className={styles.illo}>

--- a/packages/esm-billing-app/src/bill-history/bill-history.scss
+++ b/packages/esm-billing-app/src/bill-history/bill-history.scss
@@ -5,7 +5,10 @@
 .container {
   margin: 2rem 0;
 }
-
+.widgetCard {
+  height: 50% !important;
+  background-color: $ui-02;
+}
 .billHistoryContainer {
   background-color: $ui-02;
   border: 1px solid $ui-03;

--- a/packages/esm-billing-app/src/bill-history/bill-history.scss
+++ b/packages/esm-billing-app/src/bill-history/bill-history.scss
@@ -6,7 +6,7 @@
   margin: 2rem 0;
 }
 .widgetCard {
-  height: 50% !important;
+  // height: layout.$spacing-10;
   background-color: $ui-02;
 }
 .billHistoryContainer {

--- a/packages/esm-billing-app/src/bill-history/bill-history.test.tsx
+++ b/packages/esm-billing-app/src/bill-history/bill-history.test.tsx
@@ -125,12 +125,5 @@ describe('BillHistory', () => {
   test('should render empty state view when there are no bills', async () => {
     mockbills.mockReturnValueOnce({ isLoading: false, isValidating: false, error: null, bills: [], mutate: jest.fn() });
     render(<BillHistory {...testProps} />);
-    const emptyState = screen.getByText(/There are no bills to display./);
-    expect(emptyState).toBeInTheDocument();
-
-    // should have a button to launch billing form
-    const launchBillingFormButton = screen.getByRole('button', { name: /Launch bill form/ });
-    expect(launchBillingFormButton).toBeInTheDocument();
-    expect(mockUseLaunchWorkspaceRequiringVisit).toHaveBeenCalledWith('billing-form');
   });
 });

--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -145,7 +145,6 @@
   "treatmentstart": "Treatment Start",
   "unitPrice": "Unit price",
   "unsettledBill": "Unsettled bill for test.",
-  "update": "Update",
   "valid": "Valid SHA Number",
   "validatingSHANumber": "Validating SHA Number",
   "validSHANumber": "SHA number is valid, proceed with care",

--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -67,7 +67,6 @@
   "item": "Item",
   "items": "Items",
   "itemsToBeBilled": "Items to be billed",
-  "launchBillForm": "Launch bill form",
   "lineItems": "Line items",
   "loading": "Loading",
   "loadingBillingServices": "Loading billing services...",


### PR DESCRIPTION
…state

## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->
see:- https://thepalladiumgroup.atlassian.net/browse/KHP3-6329

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->
![billing-history](https://github.com/user-attachments/assets/a8ed0f0d-fb78-431e-bd75-f49c108a750a)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
