### PR TITLE
(fix) : Clinical encounter UI height issue.

### DIFF
--- a/packages/esm-patient-clinical-view-app/src/clinical-encounter/dashboard/clinical-encounter-dashboard.component.tsx
+++ b/packages/esm-patient-clinical-view-app/src/clinical-encounter/dashboard/clinical-encounter-dashboard.component.tsx
@@ -71,7 +71,7 @@ const ClinicalEncounterDashboard: React.FC<ClinicalEncounterDashboardProps> = ({
     ],
   );
   return (
-    <>
+    <div>
       <Layer>
         <Tile>
           <div className={styles.desktopHeading}>
@@ -156,7 +156,7 @@ const ClinicalEncounterDashboard: React.FC<ClinicalEncounterDashboardProps> = ({
           </TabPanels>
         </Tabs>
       </Layer>
-    </>
+    </div>
   );
 };
 export default ClinicalEncounterDashboard;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
In this PR I have fixed a small css issue that caused the height of the clinical encounters dashboard to be broken. The issue was a on the community that targetted all extension children and set their height to 100% see [here.](https://github.com/openmrs/openmrs-esm-patient-chart/blob/1d1e39cb2aaff7666bdcd8d83dcf96f64f2cf74b/packages/esm-patient-chart-app/src/patient-chart/chart-review/dashboard-view.scss#L30)

cc @donaldkibet .


## Screenshots
### Previous
![image](https://github.com/user-attachments/assets/ef5ffd38-2fea-439f-b95e-0df05e52a86b)
### Now
![image](https://github.com/user-attachments/assets/fc5d119e-b1c2-4543-b5c4-85a39ce8c526)

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
