### PR TITLE
(feat): add sidenav item linking to managecommodityprices component

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billable-services-home.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billable-services-home.component.tsx
@@ -7,6 +7,7 @@ import styles from './billable-services.scss';
 import BillingHeader from '../billing-header/billing-header.component';
 import BillManager from './bill-manager/bill-manager.component';
 import { BillableServicesSideNav } from './billable-services-sidenav.component';
+import ManageCommodityPrices from './manage-commodity-price/manage-commodity-price.component';
 
 const BillableServiceHome: React.FC = () => {
   const { t } = useTranslation();
@@ -21,6 +22,7 @@ const BillableServiceHome: React.FC = () => {
             <Route path="/" element={<BillableServicesDashboard />} />
             <Route path="/add-service" element={<AddBillableService />} />
             <Route path="/bill-manager" element={<BillManager />} />
+            <Route path="/manage-commodity-prices" element={<ManageCommodityPrices />} />
           </Routes>
         </section>
       </main>

--- a/packages/esm-billing-app/src/billable-services/billable-services-sidenav.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billable-services-sidenav.component.tsx
@@ -1,5 +1,5 @@
 import { SideNav, SideNavLink, SideNavItems } from '@carbon/react';
-import { Wallet, Money } from '@carbon/react/icons';
+import { Wallet, Money, ResultDraft } from '@carbon/react/icons';
 import { navigate, UserHasAccess } from '@openmrs/esm-framework';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -28,6 +28,14 @@ export const BillableServicesSideNav = () => {
               renderIcon={Money}
               isActive={pathname.includes('bill-manager')}>
               {t('billManager', 'Bill Manager')}
+            </SideNavLink>
+          </UserHasAccess>
+          <UserHasAccess privilege="coreapps.systemAdministration">
+            <SideNavLink
+              onClick={() => handleNavigation('manage-commodity-prices')}
+              renderIcon={ResultDraft}
+              isActive={pathname.includes('manage-commodity-prices')}>
+              {t('commodityManager', 'Manage Commodity Prices')}
             </SideNavLink>
           </UserHasAccess>
         </SideNavItems>

--- a/packages/esm-billing-app/src/billable-services/manage-commodity-price/manage-commodity-price.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/manage-commodity-price/manage-commodity-price.component.tsx
@@ -15,7 +15,7 @@ const ManageCommodityPrices = () => {
     <div>
       <Tabs onChange={handleTabChange} selectedIndex={activeTabIndex}>
         <TabList>
-          <Tab>{t('search','Search')}</Tab>
+          <Tab>{t('search', 'Search')}</Tab>
         </TabList>
       </Tabs>
     </div>

--- a/packages/esm-billing-app/src/billable-services/manage-commodity-price/manage-commodity-price.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/manage-commodity-price/manage-commodity-price.component.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Tab, Tabs, TabList } from '@carbon/react';
+
+const ManageCommodityPrices = () => {
+  const [activeTabIndex, setActiveTabindex] = useState<number>(0);
+
+  const { t } = useTranslation();
+
+  const handleTabChange = ({ selectedIndex }: { selectedIndex: number }) => {
+    setActiveTabindex(selectedIndex);
+  };
+
+  return (
+    <div>
+      <Tabs onChange={handleTabChange} selectedIndex={activeTabIndex}>
+        <TabList>
+          <Tab>{'Search'}</Tab>
+        </TabList>
+      </Tabs>
+    </div>
+  );
+};
+export default ManageCommodityPrices;

--- a/packages/esm-billing-app/src/billable-services/manage-commodity-price/manage-commodity-price.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/manage-commodity-price/manage-commodity-price.component.tsx
@@ -15,7 +15,7 @@ const ManageCommodityPrices = () => {
     <div>
       <Tabs onChange={handleTabChange} selectedIndex={activeTabIndex}>
         <TabList>
-          <Tab>{'Search'}</Tab>
+          <Tab>{t('search','Search')}</Tab>
         </TabList>
       </Tabs>
     </div>

--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -116,6 +116,7 @@
   "quantity": "Quantity",
   "referenceNumber": "Ref number",
   "save": "Save",
+  "search": "Search",
   "searchConcepts": "Search associated concept",
   "searching": "Searching",
   "searchServices": "Search services",

--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -35,6 +35,7 @@
   "claimJustification": "Claim Justification",
   "claimsItems": "Claims Items",
   "claimSummary": "Claim Summary",
+  "commodityManager": "Manage Commodity Prices",
   "Conditopns": "Conditions",
   "createClaimError": "Create Claim error",
   "date": "Date of Claimed",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
<!--
Required.
Please describe what problems your PR addresses.
-->
The added item enables privileged users to access a component through which they can edit the prices of non-pharm commodities. As it is, these commodities are billed at the buying price.

## Screenshots
![sideNavLinkItem](https://github.com/user-attachments/assets/751cf6d2-49a7-46fc-b0c3-4e6b2c712227)

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
