### PR TITLE
KHP3-6494-add-sha-number-requirement-before-pulling-shr-summary-data

### DIFF
--- a/packages/esm-shr-app/src/config-schema.ts
+++ b/packages/esm-shr-app/src/config-schema.ts
@@ -11,9 +11,15 @@ export const configSchema = {
     _description: 'The patient phone number attribute type uuid',
     _default: 'b2c38640-2603-4629-aebd-3b54f33f1e3a',
   },
+  socialHealthAuthorityIdentifierType: {
+    _type: Type.UUID,
+    _description: 'Social Health Authority Unique Identification Number',
+    _default: '24aedd37-b5be-4e08-8311-3721b8d5100d',
+  },
 };
 
 export type ReferralConfigObject = {
   nationalPatientUniqueIdentifier: string;
   phoneNumberAttributeType: string;
+  socialHealthAuthorityIdentifierType: string;
 };

--- a/packages/esm-shr-app/src/constants.ts
+++ b/packages/esm-shr-app/src/constants.ts
@@ -1,0 +1,6 @@
+export const PHONE_NUMBER_REGEX = /^(\+?254|0)((7|1)\d{8})$/;
+export const AUTH_TYPES = [
+  { value: 'otp', label: 'OTP' },
+  { value: 'pin', label: 'PIN' },
+  { value: 'biometrics', label: 'BIOMETRICS' },
+];

--- a/packages/esm-shr-app/src/hooks/usePatientIdentifiers.ts
+++ b/packages/esm-shr-app/src/hooks/usePatientIdentifiers.ts
@@ -1,18 +1,13 @@
-import { FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
-import useSWR from 'swr';
-import { PatientIdentifier } from '../types';
+import { usePatient } from '@openmrs/esm-framework';
 
 const usePatientIdentifiers = (uuid: string) => {
-  const customeRepresentation = 'custom:(display,uuid,identifier,identifierType:(uuid,display))';
-  const url = `${restBaseUrl}/patient/${uuid}/identifier?v=${customeRepresentation}`;
-  const { data, error, isLoading } = useSWR<FetchResponse<{ results: Array<PatientIdentifier> }>>(url, openmrsFetch);
+  const { isLoading, error, patient } = usePatient(uuid);
 
   return {
     isLoading,
     error,
-    identifiers: data?.data?.results ?? [],
     hasType: (typeUuid: string) =>
-      (data?.data?.results ?? []).findIndex((id) => id.identifierType.uuid === typeUuid) !== -1,
+      patient?.identifier.findIndex((identifer) => identifer.type.coding[0]?.code === typeUuid) !== -1,
   };
 };
 

--- a/packages/esm-shr-app/src/shr-summary/shr-authorization-form.workspace.tsx
+++ b/packages/esm-shr-app/src/shr-summary/shr-authorization-form.workspace.tsx
@@ -7,7 +7,8 @@ import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 import styles from './shr-forms.scss';
-import { AUTH_TYPES, authorizationSchema, generateOTP, persistOTP, sendOtp, verifyOtp } from './shr-summary.resource';
+import { authorizationSchema, generateOTP, persistOTP, sendOtp, verifyOtp } from './shr-summary.resource';
+import { AUTH_TYPES } from '../constants';
 
 interface SHRAuthorizationFormProps extends DefaultWorkspaceProps {
   patientUuid: string;
@@ -58,7 +59,6 @@ const SHRAuthorizationForm: React.FC<SHRAuthorizationFormProps> = ({
 
   return (
     <Form onSubmit={form.handleSubmit(onSubmit)}>
-      <span className={styles.formTitle}>{t('formTitle', 'Fill in the form details')}</span>
       <Stack gap={4} className={styles.grid}>
         <Column>
           <Controller

--- a/packages/esm-shr-app/src/shr-summary/shr-authorization-form.workspace.tsx
+++ b/packages/esm-shr-app/src/shr-summary/shr-authorization-form.workspace.tsx
@@ -66,7 +66,7 @@ const SHRAuthorizationForm: React.FC<SHRAuthorizationFormProps> = ({
             name="authMethod"
             render={({ field }) => (
               <RadioButtonGroup
-                legendText={t('sex', 'Sex')}
+                legendText={t('authMethod', 'Authorization Method')}
                 {...field}
                 invalid={form.formState.errors[field.name]?.message}
                 className={styles.radioGroupInput}
@@ -118,7 +118,7 @@ const SHRAuthorizationForm: React.FC<SHRAuthorizationFormProps> = ({
                       kind="tertiary"
                       onClick={handleGetOTP}
                       disabled={loadingState.isLoading || loadingState.isSuccess}>
-                      Get OTP
+                      Verify with OTP
                     </Button>
                   )}
                 </Row>

--- a/packages/esm-shr-app/src/shr-summary/shr-forms.scss
+++ b/packages/esm-shr-app/src/shr-summary/shr-forms.scss
@@ -11,7 +11,7 @@
 
 .grid {
   margin: 0 spacing.$spacing-05;
-  padding: 0rem;
+  padding: spacing.$spacing-05 0rem 0rem orem;
 }
 
 .buttonSet {
@@ -54,20 +54,6 @@
 .sectionHeader {
   @include type.type-style('heading-02');
 }
-
-:global(.omrs-breakpoint-lt-desktop) {
-  .form {
-    height: var(--tablet-workspace-window-height);
-  }
-
-  .buttonSet {
-    padding: spacing.$spacing-06 spacing.$spacing-05;
-    background-color: $ui-02;
-    justify-content: flex-end;
-    gap: spacing.$spacing-05;
-  }
-}
-
 .otpInputRow {
   display: flex;
   flex-direction: row;

--- a/packages/esm-shr-app/src/shr-summary/shr-summary.component.tsx
+++ b/packages/esm-shr-app/src/shr-summary/shr-summary.component.tsx
@@ -10,8 +10,8 @@ import { ReferralConfigObject } from '../config-schema';
 const SHRSummaryPanel = () => {
   const patientUuid = getPatientUuidFromUrl();
   const { t } = useTranslation();
-  const { nationalPatientUniqueIdentifier } = useConfig<ReferralConfigObject>();
-  const { error, isLoading, hasType, identifiers } = usePatientIdentifiers(patientUuid);
+  const { socialHealthAuthorityIdentifierType } = useConfig<ReferralConfigObject>();
+  const { error, isLoading, hasType } = usePatientIdentifiers(patientUuid);
 
   if (isLoading) {
     return <DataTableSkeleton />;
@@ -21,7 +21,7 @@ const SHRSummaryPanel = () => {
     return <ErrorState error={error} headerTitle={t('shrSummary', 'SHR Summary')} />;
   }
 
-  if (!hasType(nationalPatientUniqueIdentifier)) {
+  if (!hasType(socialHealthAuthorityIdentifierType)) {
     return (
       <div>
         <Layer>

--- a/packages/esm-shr-app/src/shr-summary/shr-summary.resource.ts
+++ b/packages/esm-shr-app/src/shr-summary/shr-summary.resource.ts
@@ -1,12 +1,7 @@
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 import { z } from 'zod';
-const PHONE_NUMBER_REGEX = /^(\+?254|0)((7|1)\d{8})$/;
-export const AUTH_TYPES = [
-  { value: 'otp', label: 'OTP' },
-  { value: 'pin', label: 'PIN' },
-  { value: 'biometrics', label: 'BIOMETRICS' },
-];
+import { PHONE_NUMBER_REGEX } from '../constants';
 
 export const authorizationSchema = z
   .object({
@@ -28,11 +23,11 @@ export const authorizationSchema = z
   );
 
 export function generateOTP(length = 5) {
-  var string = '0123456789';
+  let otpNumbers = '0123456789';
   let OTP = '';
-  var len = string.length;
+  const len = otpNumbers.length;
   for (let i = 0; i < length; i++) {
-    OTP += string[Math.floor(Math.random() * len)];
+    OTP += otpNumbers[Math.floor(Math.random() * len)];
   }
   return OTP;
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- Cleaned SHR Summary Pannel Code
- Requireing SHA Number before pulling SHR Summary in place of Initial NUPI
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

![image](https://github.com/user-attachments/assets/3e2e1e56-2e80-4a31-9431-bf8f8043d051)
![image](https://github.com/user-attachments/assets/04255439-e3c3-4aa9-9ee9-a5b4685dcefd)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

https://thepalladiumgroup.atlassian.net/browse/KHP3-6494
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
