### PR TITLE
feat: close mpesa dialog on successful mpesa payment completion

### DIFF
--- a/packages/esm-billing-app/src/invoice/payments/initiate-payment/initiate-payment.component.tsx
+++ b/packages/esm-billing-app/src/invoice/payments/initiate-payment/initiate-payment.component.tsx
@@ -47,7 +47,7 @@ const InitiatePaymentDialog: React.FC<InitiatePaymentDialogProps> = ({ closeModa
   const { mflCodeValue } = useSystemSetting('facility.mflcode');
   const [notification, setNotification] = useState<{ type: 'error' | 'success'; message: string } | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [{ requestStatus }, pollingTrigger] = useRequestStatus(setNotification);
+  const [{ requestStatus }, pollingTrigger] = useRequestStatus(setNotification, closeModal);
 
   const {
     control,

--- a/packages/esm-billing-app/src/utils.ts
+++ b/packages/esm-billing-app/src/utils.ts
@@ -85,3 +85,11 @@ export const computeTotalPrice = (items) => {
 
   return totalPrice;
 };
+
+export function waitForASecond(): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve('Resolved after a seconds');
+    }, 1000);
+  });
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR adds a UI fix to auto close the payment dialog after successfull mpesa payment.

## Screenshots

https://github.com/user-attachments/assets/4b0c6a56-071d-4512-908f-f4f2ad40708c

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other
cc @ojwanganto 
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
