### PR TITLE
(fix) Restricted manual editing of price when Editing Bill Line Item

### DIFF
--- a/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill-form.test.tsx
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill-form.test.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import { EditBillForm } from './edit-bill-form.workspace';
 import userEvent from '@testing-library/user-event';
 import { processBillPayment } from '../../../billing.resource';
 
-const mockedProcessBillPayment = processBillPayment as jest.MockedFunction<typeof processBillPayment>;
-
 jest.mock('../../../billing.resource', () => ({
-  ...jest.requireActual('../../../billing.resource'),
-  processBillPayment: jest.fn(),
+  processBillPayment: jest.fn(), // Mock the function
 }));
-
 const mockedCloseWorkspace = jest.fn();
 const mockedPromptBeforeClosing = jest.fn();
 const mockedCloseWorkspaceWithSavedChanges = jest.fn();
@@ -22,7 +18,7 @@ const mockLineItem = {
   voided: false,
   voidReason: null,
   item: '',
-  billableService: 'b4254165-ed1a-48dd-b931-c5a9c3363242:Registration New',
+  billableService: '7c1ed871-8b45-4097-a9fa-12e6efba3686:Injection',
   quantity: 1,
   price: 1000,
   priceName: 'Default',
@@ -57,6 +53,7 @@ const mockBill = {
   cashPointName: 'OPD Cash Point',
   cashPointLocation: 'Moi Teaching Refferal Hospital',
   dateCreated: 'Today, 16:19',
+  dateCreatedUnformatted: 'Today, 16:19',
   lineItems: [
     {
       uuid: '4bf2fa1c-4460-4eb6-9a22-b587c3c831a5',
@@ -83,8 +80,11 @@ const mockBill = {
 };
 
 describe('EditBillForm', () => {
+  const mockedProcessBillPayment = processBillPayment; // Access the mock
+
   test('should generate the correct payload  when the form is submitted', async () => {
     const user = userEvent.setup();
+
     render(
       <EditBillForm
         promptBeforeClosing={mockedPromptBeforeClosing}
@@ -95,7 +95,8 @@ describe('EditBillForm', () => {
         lineItem={mockLineItem}
       />,
     );
-    const unitPrice = await screen.findByPlaceholderText(/price/i);
+
+    const unitPrice = await screen.findByPlaceholderText(/New price/i);
     expect(unitPrice).toHaveValue(mockLineItem.price);
 
     const quantity = screen.getByRole('spinbutton', { name: /quantity/i });

--- a/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill-form.workspace.tsx
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill-form.workspace.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { z } from 'zod';
 import { mutate } from 'swr';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
-import { Button, ButtonSet, Form, NumberInput, InlineLoading } from '@carbon/react';
+import { Button, ComboBox, ButtonSet, Form, NumberInput, InlineLoading } from '@carbon/react';
 import {
   DefaultWorkspaceProps,
   ResponsiveWrapper,
@@ -15,11 +15,13 @@ import {
 import isEqual from 'lodash-es/isEqual';
 
 import { LineItem, MappedBill } from '../../../types';
-import { processBillPayment } from '../../../billing.resource';
+import { processBillPayment, usePaymentModes } from '../../../billing.resource';
 import styles from './edit-bill.scss';
 import { createEditBillPayload } from './edit-bill-util';
 import classNames from 'classnames';
 import { extractString } from '../../../helpers';
+import PriceField from '../../billables/services/price.component';
+import { useBillableServices } from '../../billable-service.resource';
 
 type FormData = {
   price: string;
@@ -41,7 +43,10 @@ export const EditBillForm: React.FC<EditBillFormProps> = ({ lineItem, closeWorks
   const { t } = useTranslation();
   const isTablet = useLayoutType() === 'tablet';
   const defaultValues = { price: lineItem.price.toString(), quantity: lineItem.quantity.toString() };
-
+  const [selectedPrice, setSelectedPrice] = useState(lineItem.price.toString());
+  const { billableServices, isLoading } = useBillableServices();
+  const currentBillableService =
+    billableServices.find((item) => item.uuid == lineItem.billableService?.split(':')[0]) || null;
   const {
     control,
     handleSubmit,
@@ -57,7 +62,9 @@ export const EditBillForm: React.FC<EditBillFormProps> = ({ lineItem, closeWorks
   const inputQuantity = watch('quantity');
 
   const inputDataAsObject = { price: inputPrice, quantity: inputQuantity };
-  const isUnchanged = isEqual(inputDataAsObject, defaultValues);
+  const ischanged =
+    !isEqual(inputDataAsObject.price, defaultValues.price) ||
+    !isEqual(inputDataAsObject.quantity, defaultValues.quantity);
 
   const onSubmit: SubmitHandler<FormData> = async (formData) => {
     const updateBill = createEditBillPayload(lineItem, formData, bill);
@@ -86,7 +93,9 @@ export const EditBillForm: React.FC<EditBillFormProps> = ({ lineItem, closeWorks
       closeWorkspace();
     }
   };
-
+  // if (isLoading) {
+  //   return <InlineLoading data-testid="loadingserviceprices" description={t('loading', 'Loading')} />;
+  // }
   return (
     <Form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
       <div className={styles.formContainer}>
@@ -94,24 +103,37 @@ export const EditBillForm: React.FC<EditBillFormProps> = ({ lineItem, closeWorks
           control={control}
           name="price"
           render={({ field }) => (
-            <ResponsiveWrapper>
-              <NumberInput
-                id="price"
-                {...field}
-                size="md"
-                label={'Price'}
-                placeholder={'price'}
-                invalid={!!errors.price}
-                invalidText={errors.price?.message}
-                className={styles.formField}
-                min={0}
-                readOnly
-                hideSteppers
-                disableWheel
-              />
-            </ResponsiveWrapper>
+            <ComboBox
+              onChange={({ selectedItem }) => {
+                if (selectedItem) {
+                  setSelectedPrice(selectedItem?.price?.toString());
+                  field.onChange(selectedItem?.price?.toString());
+                }
+              }}
+              titleText={t('paymentMethod', 'Payment method')}
+              items={currentBillableService?.servicePrices ?? []}
+              itemToString={(item) => (item?.name ? item.name + ' - (' + item.price + ')' : '')}
+              placeholder={t('selectPaymentMode', 'Select payment mode')}
+              disabled={isLoading}
+              invalid={!!errors.price}
+              invalidText={errors.price?.message}
+            />
           )}
         />
+        <ResponsiveWrapper>
+          <NumberInput
+            id="price"
+            size="md"
+            label={'Selected Price'}
+            value={selectedPrice}
+            placeholder={'New price'}
+            className={styles.formField}
+            min={0}
+            readOnly
+            hideSteppers
+            disableWheel
+          />
+        </ResponsiveWrapper>
         <Controller
           control={control}
           name="quantity"
@@ -126,6 +148,7 @@ export const EditBillForm: React.FC<EditBillFormProps> = ({ lineItem, closeWorks
                 invalidText={errors.quantity?.message}
                 className={styles.formField}
                 min={1}
+                initialSelectedItem={field.value}
                 id="quantity"
                 hideSteppers
                 disableWheel
@@ -140,7 +163,7 @@ export const EditBillForm: React.FC<EditBillFormProps> = ({ lineItem, closeWorks
         </Button>
         <Button
           className={styles.button}
-          disabled={!isValid || isUnchanged || isSubmitting}
+          disabled={!isValid || !ischanged || isSubmitting}
           kind="primary"
           type="submit">
           {isSubmitting ? (

--- a/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill-util.ts
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill-util.ts
@@ -1,5 +1,6 @@
 export const createEditBillPayload = (lineItem, data, bill) => {
-  const updatedLineItem = { ...lineItem, quantity: parseInt(data?.quantity) };
+  const updatedQuantityLineItem = { ...lineItem, quantity: parseInt(data?.quantity) };
+  const updatedLineItem = { ...updatedQuantityLineItem, price: parseInt(data?.price) };
 
   const updatedBill = {
     ...bill,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This fix ensures that the user does not manually edit the price on the textbox. However, the user will be able to select price from the available service prices attached to the billable item.
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
[editbill.webm](https://github.com/user-attachments/assets/f61505f9-b092-4db3-8e4c-b31abe4dd7c3)


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
