### PR TITLE
(fix) : Fix issue with display special clinic data once user is discontinued from the program

### DIFF
--- a/packages/esm-care-panel-app/src/care-programs/care-programs.component.tsx
+++ b/packages/esm-care-panel-app/src/care-programs/care-programs.component.tsx
@@ -47,6 +47,11 @@ const CarePrograms: React.FC<CareProgramsProps> = ({ patientUuid }) => {
       undefined,
       { revalidate: true },
     );
+    mutate(
+      (key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/programenrollment?patient=${patientUuid}`),
+      undefined,
+      { revalidate: true },
+    );
   };
 
   const handleCareProgramClick = useCallback(

--- a/packages/esm-patient-clinical-view-app/src/clinical-view-group/clinical-view-group.resource.ts
+++ b/packages/esm-patient-clinical-view-app/src/clinical-view-group/clinical-view-group.resource.ts
@@ -1,0 +1,34 @@
+import useSWR from 'swr';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { useMemo } from 'react';
+import uniqBy from 'lodash-es/uniqBy';
+import { PatientProgram } from '@openmrs/esm-patient-common-lib';
+const customRepresentation = `custom:(uuid,display,program,dateEnrolled,dateCompleted,location:(uuid,display))`;
+
+export const usePatientEnrollment = (patientUuid: string) => {
+  const { data, error, isLoading, isValidating } = useSWR<{ data: { results: Array<PatientProgram> } }>(
+    `${restBaseUrl}/programenrollment?patient=${patientUuid}&v=${customRepresentation}`,
+    openmrsFetch,
+  );
+
+  const activePatientEnrollment = useMemo(
+    () =>
+      data?.data.results
+        .sort((a, b) => (b.dateEnrolled > a.dateEnrolled ? 1 : -1))
+        .filter((enrollment) => enrollment.dateCompleted === null) ?? [],
+    [data?.data.results],
+  );
+
+  const patientEnrollments = useMemo(
+    () => data?.data.results.sort((a, b) => (b.dateEnrolled > a.dateEnrolled ? 1 : -1)) ?? [],
+    [data?.data.results, isValidating],
+  );
+
+  return {
+    activePatientEnrollment: uniqBy(activePatientEnrollment, (program) => program?.program?.uuid),
+    patientEnrollments: uniqBy(patientEnrollments, (program) => program?.program?.uuid),
+    error,
+    isLoading,
+    isValidating,
+  };
+};

--- a/packages/esm-patient-clinical-view-app/src/clinical-view-group/createDashboardGroup.tsx
+++ b/packages/esm-patient-clinical-view-app/src/clinical-view-group/createDashboardGroup.tsx
@@ -1,8 +1,8 @@
 import React, { memo, useMemo } from 'react';
 import { DashboardGroupExtension } from './dashboard-group.component';
 import { usePatient } from '@openmrs/esm-framework';
-import { useActivePatientEnrollment } from '@openmrs/esm-patient-common-lib';
 import { evaluateExpression } from '../utils/expression-helper';
+import { usePatientEnrollment } from './clinical-view-group.resource';
 
 type DashboardGroupProps = {
   title: string;
@@ -16,11 +16,15 @@ type DashboardGroupProps = {
 const DashboardGroup = memo(
   ({ title, slotName, isExpanded, isChild, basePath, showWhenExpression }: DashboardGroupProps) => {
     const { patient, isLoading: isLoadingPatient } = usePatient();
-    const { activePatientEnrollment, isLoading: isLoadingActiveEnrollment } = useActivePatientEnrollment(patient?.id);
+    const {
+      patientEnrollments,
+      isLoading: isLoadingActiveEnrollment,
+      isValidating,
+    } = usePatientEnrollment(patient?.id);
 
     const showGroup = useMemo(
-      () => evaluateExpression(showWhenExpression, patient, activePatientEnrollment),
-      [showWhenExpression, patient, activePatientEnrollment],
+      () => evaluateExpression(showWhenExpression, patient, patientEnrollments),
+      [showWhenExpression, patient, patientEnrollments?.length, isValidating],
     );
 
     if (isLoadingPatient || isLoadingActiveEnrollment || !showGroup) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR adds ability to show clinical nav group once a user has been discontinued from the care program
Follow up PR to ensure the dashboard link is update with every update


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
