### PR TITLE
(fix): Show regimeline based on patient age when regimen was started 

### DIFF
--- a/packages/esm-care-panel-app/src/regimen-editor/non-standard-regimen.component.tsx
+++ b/packages/esm-care-panel-app/src/regimen-editor/non-standard-regimen.component.tsx
@@ -6,13 +6,14 @@ import styles from './standard-regimen.scss';
 import { useNonStandardRegimen } from '../hooks/useNonStandardRegimen';
 import { Regimen } from '../types';
 import { usePatient } from '@openmrs/esm-framework';
-import { filterRegimenData, calculateAge } from './utils';
+import { calculateAge, filterRegimenData } from './utils';
 
 interface NonStandardRegimenProps {
   category: string;
   setNonStandardRegimens: (value: any) => void;
   setStandardRegimenLine: (value: any) => void;
   selectedRegimenType: string;
+  visitDate: Date;
 }
 
 const NonStandardRegimen: React.FC<NonStandardRegimenProps> = ({
@@ -20,6 +21,7 @@ const NonStandardRegimen: React.FC<NonStandardRegimenProps> = ({
   selectedRegimenType,
   setNonStandardRegimens,
   setStandardRegimenLine,
+  visitDate,
 }) => {
   const { t } = useTranslation();
   const { standardRegimen } = useStandardRegimen();
@@ -29,7 +31,7 @@ const NonStandardRegimen: React.FC<NonStandardRegimenProps> = ({
   const [selectedRegimens, setSelectedRegimens] = useState(Array(5).fill(''));
   const [nonStandardRegimenObjects, setStandardRegimenObjects] = useState([]);
   const { patient } = usePatient();
-  const patientAge = calculateAge(patient?.birthDate);
+  const patientAge = calculateAge(patient?.birthDate, visitDate);
   const filteredRegimenLineByAge = filterRegimenData(matchingCategory?.category, patientAge);
 
   const handleRegimenLineChange = (e) => {

--- a/packages/esm-care-panel-app/src/regimen-editor/regimen-form.component.tsx
+++ b/packages/esm-care-panel-app/src/regimen-editor/regimen-form.component.tsx
@@ -325,6 +325,7 @@ const RegimenForm: React.FC<RegimenFormProps> = ({
                         setStandardRegimen={setStandardRegimen}
                         setStandardRegimenLine={setStandardRegimenLine}
                         selectedRegimenType={selectedRegimenType}
+                        visitDate={visitDate}
                       />
                     ) : (
                       <NonStandardRegimen
@@ -332,6 +333,7 @@ const RegimenForm: React.FC<RegimenFormProps> = ({
                         setNonStandardRegimens={setNonStandardRegimens}
                         setStandardRegimenLine={setStandardRegimenLine}
                         selectedRegimenType={selectedRegimenType}
+                        visitDate={visitDate}
                       />
                     )}
                   </>

--- a/packages/esm-care-panel-app/src/regimen-editor/standard-regimen.component.tsx
+++ b/packages/esm-care-panel-app/src/regimen-editor/standard-regimen.component.tsx
@@ -4,13 +4,14 @@ import { Select, SelectItem } from '@carbon/react';
 import { useStandardRegimen } from '../hooks/useStandardRegimen';
 import styles from './standard-regimen.scss';
 import { usePatient } from '@openmrs/esm-framework';
-import { filterRegimenData, calculateAge } from './utils';
+import { calculateAge, filterRegimenData } from './utils';
 
 interface StandardRegimenProps {
   category: string;
   setStandardRegimen: (value: any) => void;
   setStandardRegimenLine: (value: any) => void;
   selectedRegimenType: string;
+  visitDate: Date;
 }
 
 const StandardRegimen: React.FC<StandardRegimenProps> = ({
@@ -18,6 +19,7 @@ const StandardRegimen: React.FC<StandardRegimenProps> = ({
   setStandardRegimen,
   setStandardRegimenLine,
   selectedRegimenType,
+  visitDate,
 }) => {
   const { t } = useTranslation();
   const { standardRegimen, isLoading, error } = useStandardRegimen();
@@ -27,7 +29,7 @@ const StandardRegimen: React.FC<StandardRegimenProps> = ({
   const [selectedRegimens, setSelectedRegimens] = useState([]);
   const matchingCategory = standardRegimen.find((item) => item.categoryCode === category);
   const { patient } = usePatient();
-  const patientAge = calculateAge(patient?.birthDate);
+  const patientAge = calculateAge(patient?.birthDate, visitDate);
   const filteredRegimenLineByAge = filterRegimenData(matchingCategory?.category, patientAge);
 
   useEffect(() => {

--- a/packages/esm-care-panel-app/src/regimen-editor/utils.tsx
+++ b/packages/esm-care-panel-app/src/regimen-editor/utils.tsx
@@ -22,22 +22,21 @@ export function filterRegimenData(regimenData: RegimenLineGroup[] | undefined, p
   return regimenData.filter((group) => group.regimenline.startsWith(filterCriterion));
 }
 
-export function calculateAge(birthDateString: string | null | undefined): number {
+export function calculateAge(birthDateString: string | null | undefined, visitDate: Date): number {
   if (!birthDateString) {
     return 0;
   }
 
-  const today = new Date();
   const birthDate = new Date(birthDateString);
 
   if (isNaN(birthDate.getTime())) {
     return 0;
   }
 
-  let age = today.getFullYear() - birthDate.getFullYear();
-  const m = today.getMonth() - birthDate.getMonth();
+  let age = visitDate.getFullYear() - birthDate.getFullYear();
+  const m = visitDate.getMonth() - birthDate.getMonth();
 
-  if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
+  if (m < 0 || (m === 0 && visitDate.getDate() < birthDate.getDate())) {
     age--;
   }
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->
When starting regimen we now calculate age of the patient as when the regimen was started. This depends on the visit date/Regimen start date the user selected. If the regimen was started when you are a child, child regimen lines will be shown. 
See the different regimen line for same patient based on the date selected

## Screenshots
![Screenshot from 2024-10-01 07-49-46](https://github.com/user-attachments/assets/44826af0-fef5-4df6-8f43-e567c2bf60c4)




![Screenshot from 2024-10-01 07-49-14](https://github.com/user-attachments/assets/179bf3d7-91b4-44b7-ad62-d7851afc63f1)


<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
