### PR TITLE
(fix) : fix billing prompt by logic for retrieving patient bill

### DIFF
--- a/packages/esm-billing-app/src/billing-prompt/billing-prompt.resource.tsx
+++ b/packages/esm-billing-app/src/billing-prompt/billing-prompt.resource.tsx
@@ -1,6 +1,6 @@
 import { Visit, useConfig, useVisit } from '@openmrs/esm-framework';
-import { useBills } from '../billing.resource';
 import { BillingConfig } from '../config-schema';
+import { usePatientBills } from '../modal/require-payment.resource';
 
 const INPATIENT_VISIT_TYPE = 'a73e2ac6-263b-47fc-99fc-e0f2c09fc914';
 const INSURANCE_PAYMENT_METHOD = 'beac329b-f1dc-4a33-9e7c-d95821a137a6';
@@ -16,7 +16,7 @@ export const useBillingPrompt = (patientUuid: string) => {
     visitAttributeTypes: { paymentMethods },
   } = useConfig<BillingConfig>();
   const { currentVisit, isLoading: isLoadingVisit } = useVisit(patientUuid);
-  const { bills, isLoading, error } = useBills(patientUuid);
+  const { patientBills: bills, isLoading, error } = usePatientBills(patientUuid);
 
   const flattenBills = bills
     .flatMap((bill) => bill.lineItems)

--- a/packages/esm-billing-app/src/billing.resource.ts
+++ b/packages/esm-billing-app/src/billing.resource.ts
@@ -17,7 +17,7 @@ import { useState } from 'react';
 import { extractString } from './helpers';
 import { z } from 'zod';
 
-const mapBillProperties = (bill: PatientInvoice): MappedBill => {
+export const mapBillProperties = (bill: PatientInvoice): MappedBill => {
   // create base object
   const mappedBill: MappedBill = {
     id: bill?.id,

--- a/packages/esm-billing-app/src/config-schema.ts
+++ b/packages/esm-billing-app/src/config-schema.ts
@@ -19,6 +19,7 @@ export interface BillingConfig {
   nationalPatientUniqueIdentifierTypeUuid: string;
   cashPointUuid: string;
   cashierUuid: string;
+  patientBillsUrl: string;
 }
 
 export const configSchema = {
@@ -131,5 +132,11 @@ export const configSchema = {
     _type: Type.String,
     _description: 'Who Generated the bill',
     _default: '54065383-b4d4-42d2-af4d-d250a1fd2590',
+  },
+  patientBillsUrl: {
+    _type: Type.String,
+    _description: 'The url to fetch patient bills',
+    _default:
+      '${restBaseUrl}/cashier/bill?v=custom:(uuid,display,voided,voidReason,adjustedBy,cashPoint:(uuid,name),cashier:(uuid,display),dateCreated,lineItems,patient:(uuid,display))',
   },
 };

--- a/packages/esm-billing-app/src/modal/require-payment.resource.tsx
+++ b/packages/esm-billing-app/src/modal/require-payment.resource.tsx
@@ -1,0 +1,40 @@
+import { openmrsFetch, restBaseUrl, useConfig } from '@openmrs/esm-framework';
+import { PatientInvoice } from '../types';
+import useSWR from 'swr';
+import { useMemo } from 'react';
+import { mapBillProperties } from '../billing.resource';
+import { config } from 'rxjs';
+/*
+ Custom hook to fetch patient bills
+ @param patientUuid - The UUID of the patient
+ @returns {
+    patientBills: Array<PatientInvoice>,
+    isLoading: boolean,
+    error: Error,
+    isValidating: boolean,
+    mutate: () => void
+ }
+*/
+export const usePatientBills = (patientUuid: string) => {
+  const { patientBillsUrl } = useConfig();
+  const url = patientBillsUrl.replace('${restBaseUrl}', restBaseUrl);
+  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<PatientInvoice> } }>(
+    patientUuid ? `${url}&patientUuid=${patientUuid}` : url,
+    openmrsFetch,
+    {
+      errorRetryCount: 2,
+    },
+  );
+
+  const patientBills = useMemo(() => {
+    return data?.data?.results?.map(mapBillProperties) ?? [];
+  }, [data?.data?.results]);
+
+  return {
+    patientBills,
+    isLoading,
+    error,
+    isValidating,
+    mutate,
+  };
+};


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR ensures that the prompt always evaluates the patient bills to ensure that past bills which haven't been settled are evaluated when determining whether to show the billing prompt. Previous version only evaluated bills on the current date time


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
