### PR TITLE
(fix) : fix: resolve service status toggle button issue caused by multiple workspace contexts

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billables/services/service-form.workspace.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/services/service-form.workspace.tsx
@@ -210,7 +210,7 @@ const AddServiceForm: React.FC<AddServiceFormProps> = ({
                     labelText={t('status', 'Status')}
                     labelA="Off"
                     labelB="On"
-                    defaultToggled
+                    defaultToggled={field.value === 'ENABLED'}
                     id="serviceStatus"
                     onToggle={(value) => (value ? field.onChange('ENABLED') : field.onChange('DISABLED'))}
                   />

--- a/packages/esm-billing-app/src/billable-services/dashboard/dashboard.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/dashboard/dashboard.component.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './dashboard.scss';
-import { WorkspaceContainer } from '@openmrs/esm-framework';
 import ClinicalCharges from '../clinical-charges.component';
 import BillingHeader from '../../billing-header/billing-header.component';
 
@@ -14,7 +13,6 @@ export const BillableServicesDashboard = () => {
       <main className={styles.servicesTableContainer}>
         <ClinicalCharges />
       </main>
-      <WorkspaceContainer overlay contextKey="billable-services" />
     </main>
   );
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
 This PR fixes an issue with forms on billing app not working correctly because of having multiple workspace context provided for the same workspace. 


## Screenshots
https://github.com/user-attachments/assets/9ec90cc7-a6c0-45f1-a847-bfbaa90127d3

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
