### PR TITLE
(Fix) Converted overflowmenuitem to Button for slot consumption

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.component.tsx
@@ -1,4 +1,4 @@
-import { OverflowMenuItem } from '@carbon/react';
+import { OverflowMenuItem, Button } from '@carbon/react';
 import { Order } from '@openmrs/esm-patient-common-lib';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -37,13 +37,9 @@ const TestOrderAction: React.FC<TestOrderProps> = ({ order }) => {
   }
 
   return (
-    <OverflowMenuItem
-      onClick={launchModal}
-      disabled={hasPendingPayment}
-      itemText={
-        hasPendingPayment ? t('unsettledBill', 'Unsettled bill for test.') : t('pickLabRequest', 'Pick Lab Request')
-      }
-    />
+    <Button kind="primary" disabled={hasPendingPayment} key={`${order.uuid}`} onClick={launchModal}>
+      {hasPendingPayment ? t('unsettledBill', 'Unsettled bill for test.') : t('pickLabRequest', 'Pick Lab Request')}
+    </Button>
   );
 };
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Converted overflowmenuitem to Button for slot consumption


## Screenshots
![Screenshot from 2024-10-04 13-39-04](https://github.com/user-attachments/assets/9054bc48-386e-452e-bc4f-a89656bb17dd)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
