### PR TITLE
(fix) : handle error on creating charge items payload and adjust bulk upload button

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
@@ -19,7 +19,7 @@ import {
   TableToolbarContent,
   TableToolbarSearch,
 } from '@carbon/react';
-import { Upload } from '@carbon/react/icons';
+import { Download, Upload } from '@carbon/react/icons';
 import { ErrorState, launchWorkspace, showModal, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { EmptyState, usePaginationInfo } from '@openmrs/esm-patient-common-lib';
 import React, { useMemo, useState } from 'react';
@@ -27,7 +27,7 @@ import { useTranslation } from 'react-i18next';
 import { convertToCurrency } from '../../helpers';
 import styles from './charge-summary-table.scss';
 import { useChargeSummaries } from './charge-summary.resource';
-import { searchTableData } from './form-helper';
+import { downloadExcelTemplateFile, searchTableData } from './form-helper';
 
 const defaultPageSize = 10;
 
@@ -148,6 +148,11 @@ const ChargeSummaryTable: React.FC = () => {
                     label={t('addCommodityChargeItem', 'Add charge item')}
                   />
                   <MenuItem onClick={openBulkUploadModal} label={t('bulkUpload', 'Bulk Upload')} renderIcon={Upload} />
+                  <MenuItem
+                    onClick={downloadExcelTemplateFile}
+                    label={t('downloadTemplate', 'Download template')}
+                    renderIcon={Download}
+                  />
                 </ComboButton>
               </TableToolbarContent>
             </TableToolbar>

--- a/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
@@ -138,10 +138,7 @@ const ChargeSummaryTable: React.FC = () => {
                 {isValidating && (
                   <InlineLoading status="active" iconDescription="Loading" description="Loading data..." />
                 )}
-                <Button onClick={openBulkUploadModal} className={styles.bulkUploadButton}>
-                  Bulk Upload <Upload className={styles.iconMarginLeft} />
-                </Button>
-                <ComboButton label={t('actions', 'Action')}>
+                <ComboButton tooltipAlignment="top-right" label={t('actions', 'Action')}>
                   <MenuItem
                     onClick={() => launchWorkspace('billable-service-form')}
                     label={t('addServiceChargeItem', 'Add charge item')}
@@ -150,6 +147,7 @@ const ChargeSummaryTable: React.FC = () => {
                     onClick={() => launchWorkspace('commodity-form')}
                     label={t('addCommodityChargeItem', 'Add charge item')}
                   />
+                  <MenuItem onClick={openBulkUploadModal} label={t('bulkUpload', 'Bulk Upload')} renderIcon={Upload} />
                 </ComboButton>
               </TableToolbarContent>
             </TableToolbar>

--- a/packages/esm-billing-app/src/billable-services/billables/commodity/commodity-form.workspace.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/commodity/commodity-form.workspace.tsx
@@ -92,9 +92,23 @@ const CommodityForm: React.FC<CommodityFormProps> = ({
     [fields, control, remove, errors],
   );
 
+  const handleError = (err) => {
+    console.error(JSON.stringify(err, null, 2));
+    showSnackbar({
+      title: t('commodityBillableCreationFailed', 'Commodity price creation failed'),
+      subtitle: t(
+        'commodityBillableCreationFailedSubtitle',
+        'The commodity price creation failed, view browser console for more details',
+      ),
+      kind: 'error',
+      isLowContrast: true,
+      timeoutInMs: 5000,
+    });
+  };
+
   return (
     <FormProvider {...formMethods}>
-      <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+      <form onSubmit={handleSubmit(onSubmit, handleError)} className={styles.form}>
         <div className={styles.formContainer}>
           <Stack className={styles.formStackControl} gap={7}>
             <StockItemSearch setValue={setValue} defaultStockItem={initialValues?.name} />

--- a/packages/esm-billing-app/src/billable-services/billables/form-helper.ts
+++ b/packages/esm-billing-app/src/billable-services/billables/form-helper.ts
@@ -143,7 +143,7 @@ export const getBulkUploadPayloadFromExcelFile = (
     !firstRowKeys.includes('name') ||
     !firstRowKeys.includes('price') ||
     !firstRowKeys.includes('disable') ||
-    !firstRowKeys.includes('category') ||
+    !firstRowKeys.includes('service_type_id') ||
     !firstRowKeys.includes('short_name')
   ) {
     return 'INVALID_TEMPLATE';
@@ -153,7 +153,7 @@ export const getBulkUploadPayloadFromExcelFile = (
 
   const payload = jsonData
     .filter((row) => {
-      if (row.category.toString().length > 1) {
+      if (row.service_type_id.toString().length > 1) {
         return true;
       } else {
         rowsWithMissingCategories.push(row);
@@ -167,7 +167,7 @@ export const getBulkUploadPayloadFromExcelFile = (
       return {
         name: row.name,
         shortName: row.short_name ?? row.name,
-        serviceType: row.category,
+        serviceType: row.service_type_id,
         servicePrices: [
           {
             paymentMode: paymentModes.find((mode) => mode.name === 'Cash').uuid,
@@ -185,7 +185,7 @@ export const getBulkUploadPayloadFromExcelFile = (
 };
 
 export function createExcelTemplateFile(): Uint8Array {
-  const headers = ['concept_id', 'name', 'short_name', 'price', 'disable', 'category'];
+  const headers = ['concept_id', 'name', 'short_name', 'price', 'disable', 'service_type_id'];
 
   const worksheet = XLSX.utils.aoa_to_sheet([headers]);
   const workbook = XLSX.utils.book_new();
@@ -198,7 +198,7 @@ export function createExcelTemplateFile(): Uint8Array {
     { wch: 20 }, // short_name
     { wch: 10 }, // price
     { wch: 10 }, // disable
-    { wch: 20 }, // category
+    { wch: 20 }, // service_type_id
   ];
   worksheet['!cols'] = colWidths;
 

--- a/packages/esm-billing-app/src/billable-services/billables/form-helper.ts
+++ b/packages/esm-billing-app/src/billable-services/billables/form-helper.ts
@@ -183,3 +183,40 @@ export const getBulkUploadPayloadFromExcelFile = (
 
   return [payload, rowsWithMissingCategories];
 };
+
+export function createExcelTemplateFile(): Uint8Array {
+  const headers = ['concept_id', 'name', 'short_name', 'price', 'disable', 'category'];
+
+  const worksheet = XLSX.utils.aoa_to_sheet([headers]);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Charge Items');
+
+  // Set column widths for better readability
+  const colWidths = [
+    { wch: 15 }, // concept_id
+    { wch: 30 }, // name
+    { wch: 20 }, // short_name
+    { wch: 10 }, // price
+    { wch: 10 }, // disable
+    { wch: 20 }, // category
+  ];
+  worksheet['!cols'] = colWidths;
+
+  // Generate the Excel file as a Uint8Array
+  const excelBuffer = XLSX.write(workbook, { bookType: 'xlsx', type: 'array' });
+  return new Uint8Array(excelBuffer);
+}
+
+export const downloadExcelTemplateFile = () => {
+  const excelBuffer = createExcelTemplateFile();
+  const blob = new Blob([excelBuffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.style.display = 'none';
+  a.href = url;
+  a.download = 'charge_items_template.xlsx';
+  document.body.appendChild(a);
+  a.click();
+  window.URL.revokeObjectURL(url);
+  document.body.removeChild(a);
+};

--- a/packages/esm-billing-app/src/billable-services/billables/services/service-form.workspace.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/services/service-form.workspace.tsx
@@ -133,9 +133,23 @@ const AddServiceForm: React.FC<AddServiceFormProps> = ({
     [servicePriceFields, control, removeServicePrice, errors],
   );
 
+  const handleError = (err) => {
+    console.error(JSON.stringify(err, null, 2));
+    showSnackbar({
+      title: t('serviceCreationFailed', 'Service creation failed'),
+      subtitle: t(
+        'serviceCreationFailedSubtitle',
+        'The service creation failed, view browser console for more details',
+      ),
+      kind: 'error',
+      isLowContrast: true,
+      timeoutInMs: 5000,
+    });
+  };
+
   return (
     <FormProvider {...formMethods}>
-      <form onSubmit={handleSubmit(onSubmit, (err) => console.error(err))} className={styles.form}>
+      <form onSubmit={handleSubmit(onSubmit, handleError)} className={styles.form}>
         <div className={styles.formContainer}>
           <Stack className={styles.formStackControl} gap={7}>
             <ResponsiveWrapper>

--- a/packages/esm-billing-app/src/billable-services/bulk-import-billable-service.modal.tsx
+++ b/packages/esm-billing-app/src/billable-services/bulk-import-billable-service.modal.tsx
@@ -62,10 +62,10 @@ export const BulkImportBillableServices = ({ closeModal }) => {
         return;
       }
 
-      const correctRowsPayload = fileReadResponse.at(0);
-      const filteredOutRows = fileReadResponse.at(1);
+      const correctRowsPayload = fileReadResponse.at(0) ?? [];
+      const filteredOutRows = fileReadResponse.at(1) ?? [];
 
-      if (filteredOutRows.length > 0) {
+      if (filteredOutRows?.length > 0) {
         createAndDownloadFilteredRowsFile(filteredOutRows as ExcelFileRow[]);
         showSnackbar({
           title: t(

--- a/packages/esm-billing-app/src/types/index.ts
+++ b/packages/esm-billing-app/src/types/index.ts
@@ -364,6 +364,6 @@ export type ExcelFileRow = {
   name: string;
   price: number;
   disable: 'false' | 'true';
-  category: number;
+  service_type_id: number;
   short_name: string;
 };

--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -45,6 +45,7 @@
   "discard": "Discard",
   "discardClaim": "Discard Claim",
   "discount": "Discount",
+  "downloadTemplate": "Download template",
   "editBillForm": "Edit Bill Form",
   "editChargeItem": "Edit charge item",
   "editServiceChargeItem": "Edit Service Charge Item",

--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -24,6 +24,7 @@
   "billPaymentRequiredMessage": "The current patient has pending bill. Advice patient to settle bill before receiving services",
   "billsList": "Bill list",
   "billTotal": "Bill total",
+  "bulkUpload": "Bulk Upload",
   "cancel": "Cancel",
   "chargeItem": "Charge items table",
   "chargeItems": "Charge Items",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR handles 3 main things
1. Add error handling in the event the payload isn't constructed correctly, this happens because charge item may have been created with the wrong concept id. In this event @ojwanganto we might want to provide ability to validate the bulk import to ascertain that charge items created using this method have valid concept uuids.
2. Moved the bulk import functionality under the `Actions` combo box to centralized functionality on the summary table.
3. Add ability to download `template excel` file to be used for bulk upload. 


## Screenshots
https://github.com/user-attachments/assets/b8fac0dc-f598-4668-8773-386020b0f3a4


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
