### PR TITLE
fix: correctly early return when no payment point is provided

### DIFF
--- a/packages/esm-billing-app/src/payment-points/payment-point/clock-in.component.tsx
+++ b/packages/esm-billing-app/src/payment-points/payment-point/clock-in.component.tsx
@@ -115,46 +115,48 @@ export const ClockIn = ({ closeModal, paymentPoint }: { closeModal: () => void; 
   };
 
   if (shouldPromptUser) {
-    <Form onSubmit={handleSubmit(onSubmit)}>
-      <ModalHeader closeModal={undefined}>Clock In</ModalHeader>
-      <ModalBody>
-        {isLoadingPaymentPoints ? (
-          <SelectSkeleton />
-        ) : (
-          <Select
-            {...register('paymentPointUUID')}
-            labelText={t('selectPaymentPoint', 'Select payment point')}
-            helperText={t('selectPaymentPointMessage', 'Select the payment point on which you will be clocked in.')}
-            label={t('paymentPoint', 'Payment point')}
-            placeholder={t('pleaseSelectPaymentPoint', 'Please select a payment point')}
-            invalid={!!errors.paymentPointUUID}
-            invalidText={errors.paymentPointUUID?.message}>
-            {paymentPoints.map((point) => (
-              <SelectItem value={point.uuid} text={point.name} />
-            ))}
-          </Select>
-        )}
-      </ModalBody>
-      <ModalFooter>
-        <Button
-          kind="secondary"
-          onClick={shouldPromptUser ? undefined : closeModal}
-          type="button"
-          disabled={shouldPromptUser}>
-          {t('cancel', 'Cancel')}
-        </Button>
-        <Button type="submit" disabled={isLoading || error || !providerUUID || !isValid}>
-          {isSubmitting ? (
-            <>
-              <Loading withOverlay={false} small />
-              {t('clockingIn', 'Clocking in')}
-            </>
+    return (
+      <Form onSubmit={handleSubmit(onSubmit)}>
+        <ModalHeader closeModal={undefined}>Clock In</ModalHeader>
+        <ModalBody>
+          {isLoadingPaymentPoints ? (
+            <SelectSkeleton />
           ) : (
-            t('clockIn', 'Clock In')
+            <Select
+              {...register('paymentPointUUID')}
+              labelText={t('selectPaymentPoint', 'Select payment point')}
+              helperText={t('selectPaymentPointMessage', 'Select the payment point on which you will be clocked in.')}
+              label={t('paymentPoint', 'Payment point')}
+              placeholder={t('pleaseSelectPaymentPoint', 'Please select a payment point')}
+              invalid={!!errors.paymentPointUUID}
+              invalidText={errors.paymentPointUUID?.message}>
+              {paymentPoints.map((point) => (
+                <SelectItem value={point.uuid} text={point.name} />
+              ))}
+            </Select>
           )}
-        </Button>
-      </ModalFooter>
-    </Form>;
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            kind="secondary"
+            onClick={shouldPromptUser ? undefined : closeModal}
+            type="button"
+            disabled={shouldPromptUser}>
+            {t('cancel', 'Cancel')}
+          </Button>
+          <Button type="submit" disabled={isLoading || error || !providerUUID || !isValid}>
+            {isSubmitting ? (
+              <>
+                <Loading withOverlay={false} small />
+                {t('clockingIn', 'Clocking in')}
+              </>
+            ) : (
+              t('clockIn', 'Clock In')
+            )}
+          </Button>
+        </ModalFooter>
+      </Form>
+    );
   }
 
   return (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR fixes a small early return issue when no payment points are provided to the clock-in component. Fixes an issue where the component would crash with undefined on the payment point name.
## Screenshots
![image](https://github.com/user-attachments/assets/67c35ffb-0bb8-4e89-b25f-46458e0b8eea)


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
