### PR TITLE
(fix) : correctly filter bills by service types

### DIFF
--- a/packages/esm-billing-app/src/billable-services/payment-history/payment-history-viewer.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/payment-history/payment-history-viewer.component.tsx
@@ -17,6 +17,7 @@ import { useParams } from 'react-router-dom';
 import { useBills } from '../../billing.resource';
 import { useClockInStatus, usePaymentPoints } from '../../payment-points/payment-points.resource';
 import { MappedBill, PaymentStatus } from '../../types';
+import { useServiceTypes } from '../billable-service.resource';
 import { AppliedFilterTags } from './applied-filter-tages.component';
 import { CashierFilter } from './cashier-filter.component';
 import { PaymentHistoryTable } from './payment-history-table.component';
@@ -40,6 +41,7 @@ export const PaymentHistoryViewer = () => {
   const { paymentPointUUID } = useParams();
   const { paymentPoints } = usePaymentPoints();
   const { isClockedInCurrentPaymentPoint } = useClockInStatus(paymentPointUUID);
+  const { serviceTypes } = useServiceTypes();
 
   const isOnPaymentPointPage = Boolean(paymentPointUUID);
   const paidBillsResponse = useBills('', isOnPaymentPointPage ? '' : PaymentStatus.PAID, dateRange[0], dateRange[1]);
@@ -165,7 +167,7 @@ export const PaymentHistoryViewer = () => {
 
   const serviceTypeTags = selectedServiceTypeCheckboxes.map((t) => {
     return {
-      tag: t,
+      tag: serviceTypes.find((sT) => sT.uuid === t)?.display,
       type: 'Service Type',
     };
   });

--- a/packages/esm-billing-app/src/billable-services/payment-history/service-type-filter.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/payment-history/service-type-filter.component.tsx
@@ -41,11 +41,12 @@ export const ServiceTypeFilter = ({ onApplyFilter, onResetFilter, bills }: Table
     const isChecked = e.target.checked;
 
     const checkboxValue: HTMLSpanElement | null = document.querySelector(`label[for="${checkboxId}"]`);
+    const serviceTypeUUID = billsServiceTypes.find((s) => s.display === checkboxValue.innerText).uuid;
 
     if (isChecked && checkboxValue) {
-      setSelectedCheckboxes([...selectedCheckboxes, checkboxValue.innerText]);
+      setSelectedCheckboxes([...selectedCheckboxes, serviceTypeUUID]);
     } else {
-      setSelectedCheckboxes(selectedCheckboxes.filter((item) => item !== checkboxValue?.innerText));
+      setSelectedCheckboxes(selectedCheckboxes.filter((item) => item !== serviceTypeUUID));
     }
   };
 
@@ -75,7 +76,7 @@ export const ServiceTypeFilter = ({ onApplyFilter, onResetFilter, bills }: Table
                 labelText={type.display}
                 id={`checkbox-${type.display}`}
                 onChange={handleCheckboxChange}
-                checked={selectedCheckboxes.includes(type.display)}
+                checked={selectedCheckboxes.includes(type.uuid)}
               />
             ))}
           </fieldset>

--- a/packages/esm-billing-app/src/billable-services/payment-history/use-bills-service-types.tsx
+++ b/packages/esm-billing-app/src/billable-services/payment-history/use-bills-service-types.tsx
@@ -1,24 +1,15 @@
 import { MappedBill } from '../../types';
 import { useServiceTypes } from '../billable-service.resource';
-import { useChargeSummaries } from '../billables/charge-summary.resource';
 
 export const useBillsServiceTypes = (bills: MappedBill[]) => {
   const { serviceTypes, isLoading } = useServiceTypes();
-  const { isLoading: isLoadingChargeSummaries, chargeSummaryItems } = useChargeSummaries();
-
-  const allLineItemBillableServicesUUIDs = bills
-    .map((bill) => [...bill.lineItems.map((item) => item.billableService.split(':').at(0))])
+  const lineItemServiceTypeUUIDS = bills
+    .map((bill) => bill.lineItems.map((lineItem) => lineItem.serviceTypeUuid))
     .flat();
-
-  //finding the billable service`s service type
-  const lineItemServiceTypeUUIDS = allLineItemBillableServicesUUIDs.map(
-    (billableServiceUUID) => chargeSummaryItems.find((item) => item.uuid === billableServiceUUID)?.serviceType?.uuid,
-  );
-
-  const uniqueLineItemServiceType = Array.from(new Set(lineItemServiceTypeUUIDS));
+  const uniqueLineItemServiceTypeUUIDs = Array.from(new Set(lineItemServiceTypeUUIDS));
 
   return {
-    isLoading: isLoading || isLoadingChargeSummaries,
-    billsServiceTypes: serviceTypes.filter((sType) => uniqueLineItemServiceType.includes(sType.uuid)),
+    isLoading: isLoading,
+    billsServiceTypes: serviceTypes.filter((sType) => uniqueLineItemServiceTypeUUIDs.includes(sType.uuid)),
   };
 };

--- a/packages/esm-billing-app/src/types/index.ts
+++ b/packages/esm-billing-app/src/types/index.ts
@@ -70,6 +70,7 @@ export interface LineItem {
   resourceVersion: string;
   paymentStatus: string;
   itemOrServiceConceptUuid: string;
+  serviceTypeUuid: string;
 }
 
 interface PatientLink {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR fixes a slight bug on the payment history page where filter by service types was not working. The root cause is that the backend does not send over a service type name in the `LineItem` payload _(my filtering logic depends on its presence, how it worked before when I opened  #372 I have no idea)_ so I had to think of a workaround and use the service type uuid instead since it is provided correctly.

## Screenshots
![image](https://github.com/user-attachments/assets/0de4e681-0a2f-4d82-8192-4686635c7aa3)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
