### PR TITLE
(fix) : Fix benefits package css affecting global styles for search component

### DIFF
--- a/packages/esm-billing-app/src/benefits-package/forms/benefits-eligibility-request-form.scss
+++ b/packages/esm-billing-app/src/benefits-package/forms/benefits-eligibility-request-form.scss
@@ -1,18 +1,17 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
 @use '@carbon/layout';
-@import '~@openmrs/esm-styleguide/src/vars';
 
 .grid {
   margin: 0 spacing.$spacing-05;
   padding: spacing.$spacing-05 0rem 0rem 0rem;
-}
 
-form {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+  form {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
 }
 
 .formTitle {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Fixes a regression introduced by this https://github.com/palladiumkenya/kenyaemr-esm-3.x/pull/329


## Screenshots
## Regression
![Screenshot 2024-10-16 at 13 25 37](https://github.com/user-attachments/assets/8735e886-966f-4ed5-a612-844e5f44008f)

## Fix
![Screenshot 2024-10-16 at 13 31 08](https://github.com/user-attachments/assets/8d94f9a8-cfc9-47c2-89cb-7e3a232659ac)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other
@Omoshlawi @its-kios09 @makombe @amosmachora @FelixKiprotich350 
IMO let's ensure all SCSS is properly scoped to avoid affecting global styles. This will help maintain the integrity of our overall styling and prevent unintended side effects, like in this case.

Specifically:
1. Use BEM naming conventions or CSS modules to create unique class names
2. Avoid styling elements directly; use classes instead, in this case we are directly targeting the `form` element
3. Consider using `:local()` for PostCSS to scope styles locally.

Thanks!