### PR TITLE
(fix) KHP-6723: Enable regimen initiation for TB clients

### DIFF
--- a/packages/esm-care-panel-app/src/regimen-editor/utils.tsx
+++ b/packages/esm-care-panel-app/src/regimen-editor/utils.tsx
@@ -19,7 +19,7 @@ export function filterRegimenData(regimenData: RegimenLineGroup[] | undefined, p
   }
 
   const filterCriterion = patientAge > 14 ? 'Adult' : 'Child';
-  return regimenData.filter((group) => group.regimenline.includes(filterCriterion));
+  regimenData.filter((group) => group.regimenline && group.regimenline.includes(filterCriterion));
 }
 
 export function calculateAge(birthDateString: string | null | undefined, visitDate: Date): number {

--- a/packages/esm-care-panel-app/src/regimen-editor/utils.tsx
+++ b/packages/esm-care-panel-app/src/regimen-editor/utils.tsx
@@ -19,7 +19,7 @@ export function filterRegimenData(regimenData: RegimenLineGroup[] | undefined, p
   }
 
   const filterCriterion = patientAge > 14 ? 'Adult' : 'Child';
-  return regimenData.filter((group) => group.regimenline.startsWith(filterCriterion));
+  return regimenData.filter((group) => group.regimenline.includes(filterCriterion));
 }
 
 export function calculateAge(birthDateString: string | null | undefined, visitDate: Date): number {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary


The TB regimen line were being filtered out hence no way one would be able to select the regimen. The fix here is to ensure that TB regimen lines are getting included and still take into account the age factor.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
