### PR TITLE
(feat) KHP3-6909: Expand test order slot to allow passing of additional props

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.component.tsx
@@ -5,22 +5,28 @@ import { useTranslation } from 'react-i18next';
 import { useTestOrderBillStatus } from './test-order-action.resource';
 import { showModal } from '@openmrs/esm-framework';
 
-type TestOrderProps = { order: Order };
+type TestOrderProps = {
+  order: Order;
+  modalName?: string;
+  additionalProps?: Record<string, unknown>;
+  actionText?: string;
+};
 
 enum FulfillerStatus {
   IN_PROGRESS = 'IN_PROGRESS',
 }
 
-const TestOrderAction: React.FC<TestOrderProps> = React.memo(({ order }) => {
+const TestOrderAction: React.FC<TestOrderProps> = React.memo(({ order, modalName, additionalProps, actionText }) => {
   const { t } = useTranslation();
   const { isLoading, hasPendingPayment } = useTestOrderBillStatus(order.uuid, order.patient.uuid);
 
   const launchModal = useCallback(() => {
-    const dispose = showModal('pickup-lab-request-modal', {
+    const dispose = showModal(modalName ?? 'pickup-lab-request-modal', {
       closeModal: () => dispose(),
       order,
+      ...(additionalProps && { additionalProps }),
     });
-  }, [order]);
+  }, [order, additionalProps, modalName]);
 
   // Show the test order if the following conditions are met:
   // 1. The current visit is in-patient
@@ -38,7 +44,9 @@ const TestOrderAction: React.FC<TestOrderProps> = React.memo(({ order }) => {
 
   return (
     <Button kind="primary" disabled={hasPendingPayment} onClick={launchModal}>
-      {hasPendingPayment ? t('unsettledTestBill', 'Unsettled test bill.') : t('pickLabRequest', 'Pick Lab Request')}
+      {hasPendingPayment
+        ? t('unsettledBill', 'Unsettled bill.')
+        : actionText ?? t('pickLabRequest', 'Pick Lab Request')}
     </Button>
   );
 });

--- a/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.test.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.test.tsx
@@ -8,6 +8,10 @@ import { showModal } from '@openmrs/esm-framework';
 
 jest.mock('./test-order-action.resource');
 
+const testProps = {
+  order: { uuid: '123', patient: { uuid: '456' } } as Order,
+};
+
 describe('TestOrderAction', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -15,24 +19,24 @@ describe('TestOrderAction', () => {
 
   test('should render loading when isLoading is true', () => {
     jest.spyOn(resource, 'useTestOrderBillStatus').mockReturnValue({ isLoading: true, hasPendingPayment: false });
-    render(<TestOrderAction order={{ uuid: '123', patient: { uuid: '456' } } as Order} />);
+    render(<TestOrderAction {...testProps} />);
     expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
   test("should display `Unsettled bill for test` when there's a pending payment", () => {
     jest.spyOn(resource, 'useTestOrderBillStatus').mockReturnValue({ isLoading: false, hasPendingPayment: true });
-    render(<TestOrderAction order={{ uuid: '123', patient: { uuid: '456' } } as Order} />);
-    expect(screen.getByText('Unsettled test bill.')).toBeInTheDocument();
+    render(<TestOrderAction {...testProps} />);
+    expect(screen.getByText('Unsettled bill.')).toBeInTheDocument();
   });
 
   test("should display `Pick Lab Request` when there's no pending payment", async () => {
     const user = userEvent.setup();
     jest.spyOn(resource, 'useTestOrderBillStatus').mockReturnValue({ isLoading: false, hasPendingPayment: false });
-    render(<TestOrderAction order={{ uuid: '123', patient: { uuid: '456' } } as Order} />);
+    render(<TestOrderAction {...testProps} />);
     const pickLabRequestMenuItem = screen.getByText('Pick Lab Request');
     await user.click(pickLabRequestMenuItem);
 
-    expect(screen.queryByText('Unsettled test bill.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unsettled bill.')).not.toBeInTheDocument();
     expect(showModal).toBeCalledWith('pickup-lab-request-modal', {
       closeModal: expect.any(Function),
       order: { patient: { uuid: '456' }, uuid: '123' },

--- a/packages/esm-billing-app/src/index.ts
+++ b/packages/esm-billing-app/src/index.ts
@@ -197,11 +197,11 @@ export function startupApp() {
   );
 
   defineConfigSchema(moduleName, configSchema);
-  // registerFeatureFlag(
-  //   'healthInformationExchange',
-  //   'Health Information Exchange (HIE)',
-  //   'HIE feature flag, this enables and disables the HIE feature',
-  // );
+  registerFeatureFlag(
+    'healthInformationExchange',
+    'Health Information Exchange (HIE)',
+    'HIE feature flag, this enables and disables the HIE feature',
+  );
 }
 
 export const bulkImportBillableServicesModal = getSyncLifecycle(BulkImportBillableServices, options);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
To integrate billing with various order modules (Imaging, Procedures, and Drugs). This (PR) enhances the bill payment status action button to accommodate different needs:

When users click "Pick Order," the system should be able to launch module-specific modals for:
1. Lab tests
2. Procedures
3. Drugs
4. Imaging(i.e Radiology)

## Screenshots
No UI changes

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
