### PR TITLE
(fix) KHP3-6911: Fix provider app bugs - gender field, HWR credentials, and identifier type issues

### DIFF
--- a/packages/esm-providers-app/src/constants.ts
+++ b/packages/esm-providers-app/src/constants.ts
@@ -1,3 +1,21 @@
 export const moduleName = '@kenyaemr/esm-providers-app';
 export const providerBasePath = `${window.spaBase}/home/providers`;
 export const defaultPageSize = 5;
+/**
+ * Represents the error response from the Health Care Worker Registry API
+ * when no valid credentials are provided or found.
+ * @constant {string}
+ */
+export const HWR_API_NO_CREDENTIALS = 'NO_API_CREDENNTIALS';
+/**
+ * Represents the error response from the Health Care Worker Registry API
+ * when when resource is not found
+ * @constant {string}
+ */
+export const NOT_FOUND = 'NOT_FOUND';
+/**
+ * Represents the error response from the Health Care Worker Registry API
+ * When Uknown error occures
+ * @constant {string}
+ */
+export const UNKNOWN = 'UNKNOWN';

--- a/packages/esm-providers-app/src/table/provider-data-table.resource.ts
+++ b/packages/esm-providers-app/src/table/provider-data-table.resource.ts
@@ -4,7 +4,7 @@ import { ProviderResponse, UserRoles } from '../types';
 
 export function useProviders() {
   const customRepresentation =
-    'custom:(uuid,display,person:(uuid,display),identifier,attributes:(uuid,display,attributeType:(uuid,display),value:(uuid,display,tags:(uuid,display)))';
+    'custom:(uuid,display,person:(uuid,display,gender),identifier,attributes:(uuid,display,attributeType:(uuid,display),value:(uuid,display,tags:(uuid,display)))';
 
   const encodedRepresentation = encodeURIComponent(customRepresentation);
   const url = `/ws/rest/v1/provider?v=${encodedRepresentation}`;

--- a/packages/esm-providers-app/src/workspace/hook/provider-form.resource.ts
+++ b/packages/esm-providers-app/src/workspace/hook/provider-form.resource.ts
@@ -3,6 +3,7 @@ import useSWR, { mutate } from 'swr';
 import useSWRImmutable from 'swr/immutable';
 import { ConfigObject } from '../../config-schema';
 import { FacilityResponse, Provider, ProviderResponse, RolesResponse, User } from '../../types';
+import { HWR_API_NO_CREDENTIALS, NOT_FOUND, UNKNOWN } from '../../constants';
 
 export const useIdentifierTypes = () => {
   const { isLoading, data, error } = useSWRImmutable<{ data: { results: Array<OpenmrsResource> } }>(
@@ -54,9 +55,11 @@ export const searchHealthCareWork = async (identifierType: string, identifierNum
     return await response.json();
   }
   if (response.status === 401) {
-    throw new Error('NO_API_CREDENNTIALS');
+    throw new Error(HWR_API_NO_CREDENTIALS);
+  } else if (response.status === 404) {
+    throw new Error(NOT_FOUND);
   }
-  throw new Error();
+  throw new Error(UNKNOWN);
 };
 export const createProvider = (payload) => {
   const url = `${restBaseUrl}/provider`;

--- a/packages/esm-providers-app/src/workspace/hook/provider-form.resource.ts
+++ b/packages/esm-providers-app/src/workspace/hook/provider-form.resource.ts
@@ -1,9 +1,8 @@
-import { FetchResponse, openmrsFetch, OpenmrsResource, restBaseUrl, useConfig } from '@openmrs/esm-framework';
-import { useCallback, useState } from 'react';
-import useSWRImmutable from 'swr/immutable';
-import { FacilityResponse, Practitioner, Provider, ProviderResponse, RolesResponse, User } from '../../types';
+import { FetchResponse, makeUrl, openmrsFetch, OpenmrsResource, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import useSWR, { mutate } from 'swr';
+import useSWRImmutable from 'swr/immutable';
 import { ConfigObject } from '../../config-schema';
+import { FacilityResponse, Provider, ProviderResponse, RolesResponse, User } from '../../types';
 
 export const useIdentifierTypes = () => {
   const { isLoading, data, error } = useSWRImmutable<{ data: { results: Array<OpenmrsResource> } }>(
@@ -49,8 +48,15 @@ export const searchHealthCareWork = async (identifierType: string, identifierNum
   const url = `${restBaseUrl}/kenyaemr/practitionersearch?${convertToIdenitifertype(
     identifierType,
   )}=${identifierNumber}`;
-  const response = await openmrsFetch(url);
-  return response.json();
+  // Not using openmrsfetch to avoid automatic ending of current session due to 401(Unauthorized) status error it throws
+  const response = await fetch(makeUrl(url));
+  if (response.ok) {
+    return await response.json();
+  }
+  if (response.status === 401) {
+    throw new Error('NO_API_CREDENNTIALS');
+  }
+  throw new Error();
 };
 export const createProvider = (payload) => {
   const url = `${restBaseUrl}/provider`;

--- a/packages/esm-providers-app/src/workspace/provider-form.scss
+++ b/packages/esm-providers-app/src/workspace/provider-form.scss
@@ -102,3 +102,11 @@
   align-items: center;
   display: flex;
 }
+
+.loadingContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}

--- a/packages/esm-providers-app/src/workspace/provider-form.workspace.tsx
+++ b/packages/esm-providers-app/src/workspace/provider-form.workspace.tsx
@@ -8,30 +8,30 @@ import {
   DatePickerInput,
   Form,
   InlineLoading,
+  Loading,
   MultiSelect,
   PasswordInput,
   Row,
   Search,
   Stack,
   Switch,
-  Tag,
   TextInput,
-  Tile,
 } from '@carbon/react';
 import { GenderFemale, GenderMale, Query } from '@carbon/react/icons';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { parseDate, restBaseUrl, showModal, showSnackbar, useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { parseDate, showModal, showSnackbar, useConfig, useLayoutType } from '@openmrs/esm-framework';
 import React, { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { mutate } from 'swr';
 import { z } from 'zod';
 import { ConfigObject } from '../config-schema';
 import { Facility, Practitioner, ProviderResponse, User } from '../types';
 import {
   createProvider,
+  createProviderAttribute,
   createUser,
   searchHealthCareWork,
-  createProviderAttribute,
   updateProviderAttributes,
   updateProviderPerson,
   updateProviderUser,
@@ -40,7 +40,6 @@ import {
   useRoles,
 } from './hook/provider-form.resource';
 import styles from './provider-form.scss';
-import { mutate } from 'swr';
 
 const providerFormSchema = z
   .object({
@@ -71,7 +70,7 @@ const ProviderForm: React.FC<ProvideModalProps> = ({ closeWorkspace, provider, u
   const { t } = useTranslation();
   const layout = useLayoutType();
   const controlSize = layout === 'tablet' ? 'xl' : 'sm';
-  const { providerIdentifierTypes } = useIdentifierTypes();
+  const { providerIdentifierTypes, isLoading } = useIdentifierTypes();
   const { roles, isLoading: isLoadingRoles } = useRoles();
   const [facilitySearchTerm, setFacilitySearchTerm] = useState('');
   const [selectedFacility, setSelectedFacility] = useState<Facility | null>(null);
@@ -109,7 +108,7 @@ const ProviderForm: React.FC<ProvideModalProps> = ({ closeWorkspace, provider, u
     },
   });
 
-  const defualtValueCombox = providerIdentifierTypes?.find((item) => item.display === searchHWR.identifierType);
+  const defualtValueCombox = providerIdentifierTypes?.find((item) => item.uuid === searchHWR.identifierType);
   const handleSearch = async () => {
     try {
       setSearchHWR({ ...searchHWR, isHWRLoading: true });
@@ -253,6 +252,14 @@ const ProviderForm: React.FC<ProvideModalProps> = ({ closeWorkspace, provider, u
       });
     }
   };
+
+  if (isLoading) {
+    return (
+      <div className={styles.loadingContainer}>
+        <Loading small withOverlay={false} />
+      </div>
+    );
+  }
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)} className={styles.form__container}>

--- a/packages/esm-providers-app/src/workspace/provider-form.workspace.tsx
+++ b/packages/esm-providers-app/src/workspace/provider-form.workspace.tsx
@@ -40,6 +40,7 @@ import {
   useRoles,
 } from './hook/provider-form.resource';
 import styles from './provider-form.scss';
+import { HWR_API_NO_CREDENTIALS, NOT_FOUND, UNKNOWN } from '../constants';
 
 const providerFormSchema = z
   .object({
@@ -132,11 +133,17 @@ const ProviderForm: React.FC<ProvideModalProps> = ({ closeWorkspace, provider, u
         },
       });
     } catch (error) {
-      if (error.message === 'NO_API_CREDENNTIALS') {
+      if (error.message === HWR_API_NO_CREDENTIALS) {
         showSnackbar({
           kind: 'error',
           title: 'Error',
           subtitle: t('noApiCredentials', 'Health Care Worker Registry API credentials not configured'),
+        });
+      } else if (error.message === NOT_FOUND || error.message === UNKNOWN) {
+        showSnackbar({
+          kind: 'error',
+          title: 'Error',
+          subtitle: t('errorMessage', 'Error Occured while searching Healthcare work.'),
         });
       }
       showModal('hwr-empty-modal');
@@ -367,12 +374,7 @@ const ProviderForm: React.FC<ProvideModalProps> = ({ closeWorkspace, provider, u
             control={control}
             name="gender"
             render={({ field }) => (
-              <ContentSwitcher
-                selectedIndex={field.value == 'M' ? 0 : 1}
-                onChange={(value) => {
-                  let { index, name, text } = value;
-                  field.onChange(name);
-                }}>
+              <ContentSwitcher selectedIndex={field.value == 'M' ? 0 : 1} onChange={({ name }) => field.onChange(name)}>
                 <Switch
                   name="M"
                   text={

--- a/packages/esm-providers-app/src/workspace/provider-form.workspace.tsx
+++ b/packages/esm-providers-app/src/workspace/provider-form.workspace.tsx
@@ -133,7 +133,7 @@ const ProviderForm: React.FC<ProvideModalProps> = ({ closeWorkspace, provider, u
         },
       });
     } catch (error) {
-      if (error.message == 'NO_API_CREDENNTIALS') {
+      if (error.message === 'NO_API_CREDENNTIALS') {
         showSnackbar({
           kind: 'error',
           title: 'Error',

--- a/packages/esm-providers-app/src/workspace/provider-form.workspace.tsx
+++ b/packages/esm-providers-app/src/workspace/provider-form.workspace.tsx
@@ -350,14 +350,15 @@ const ProviderForm: React.FC<ProvideModalProps> = ({ closeWorkspace, provider, u
         <Column>
           <span className={styles.form__gender}>{t('gender', 'Gender*')}</span>
           <Controller
-            name="gender"
             control={control}
+            name="gender"
             render={({ field }) => (
               <ContentSwitcher
-                id="form__content_switch"
-                selectedIndex={field.value === 'F' ? 1 : 0}
-                selectionMode="manual"
-                onChange={(event) => field.onChange(event.index === 0 ? 'M' : 'F')}>
+                selectedIndex={field.value == 'M' ? 0 : 1}
+                onChange={(value) => {
+                  let { index, name, text } = value;
+                  field.onChange(name);
+                }}>
                 <Switch
                   name="M"
                   text={
@@ -365,7 +366,6 @@ const ProviderForm: React.FC<ProvideModalProps> = ({ closeWorkspace, provider, u
                       <GenderMale /> Male
                     </>
                   }
-                  selected={field.value === 'M'}
                 />
                 <Switch
                   name="F"
@@ -374,7 +374,6 @@ const ProviderForm: React.FC<ProvideModalProps> = ({ closeWorkspace, provider, u
                       <GenderFemale /> Female
                     </>
                   }
-                  selected={field.value === 'F'}
                 />
               </ContentSwitcher>
             )}

--- a/packages/esm-providers-app/src/workspace/provider-form.workspace.tsx
+++ b/packages/esm-providers-app/src/workspace/provider-form.workspace.tsx
@@ -133,6 +133,13 @@ const ProviderForm: React.FC<ProvideModalProps> = ({ closeWorkspace, provider, u
         },
       });
     } catch (error) {
+      if (error.message == 'NO_API_CREDENNTIALS') {
+        showSnackbar({
+          kind: 'error',
+          title: 'Error',
+          subtitle: t('noApiCredentials', 'Health Care Worker Registry API credentials not configured'),
+        });
+      }
       showModal('hwr-empty-modal');
     } finally {
       setSearchHWR({ ...searchHWR, isHWRLoading: false });


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Fixed:
- Gender field not picking current provider gender when performing update due to the field not being included in provider custom representation
- Auto logout when invalid HWR Credentials are used or are not configured (No not logging out rather showing appropriate error message)
- Default identifier type not autofilling due to identifier search by display for a uuid value and also identifier types loading state not handled

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
https://github.com/user-attachments/assets/dc7556cf-66ff-4c44-9d9c-286c726dbfbd


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

https://thepalladiumgroup.atlassian.net/browse/KHP3-6911
https://thepalladiumgroup.atlassian.net/browse/KHP3-6912
 https://thepalladiumgroup.atlassian.net/browse/KHP3-6913

<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
