### PR TITLE
(fix) : replace NUPI with SHA number

### DIFF
--- a/packages/esm-billing-app/src/billing-form/hie.resource.tsx
+++ b/packages/esm-billing-app/src/billing-form/hie.resource.tsx
@@ -3,11 +3,37 @@ import useSWR from 'swr';
 
 type EligibilityResponse = { message: { eligible: 0 | 1; possible_solution: string; reason: string } };
 
+type HIEEligibilityResponse = {
+  // TODO
+  eligibility_response: EligibilityResponse;
+};
+
 type HIEAPIResponse = {
   insurer: string;
   inforce: boolean;
   start: string;
-  eligibility_response: EligibilityResponse;
+  end: string;
+};
+
+export const useHIEEligibility = (patientUuid: string) => {
+  const url = `${restBaseUrl}/insuranceclaims/CoverageEligibilityRequest?patientUuid=${patientUuid}`;
+  const { data, error, isLoading, mutate } = useSWR<{ data: Array<HIEEligibilityResponse> }>(url, openmrsFetch, {
+    errorRetryCount: 0,
+  });
+
+  return {
+    data: [],
+    // data:
+    //   data?.data.map((d) => {
+    //     return {
+    //       ...d,
+    //       eligibility_response: JSON.parse(d.eligibility_response as unknown as string) as EligibilityResponse,
+    //     };
+    //   }) ?? [],
+    isLoading,
+    error,
+    mutate,
+  };
 };
 
 export const useHIESubscription = (patientUuid: string) => {
@@ -17,13 +43,7 @@ export const useHIESubscription = (patientUuid: string) => {
   });
 
   return {
-    data:
-      data?.data.map((d) => {
-        return {
-          ...d,
-          eligibility_response: JSON.parse(d.eligibility_response as unknown as string) as EligibilityResponse,
-        };
-      }) ?? [],
+    hieSubscriptions: data?.data ?? [],
     isLoading,
     error,
     mutate,

--- a/packages/esm-billing-app/src/billing-form/hie.resource.tsx
+++ b/packages/esm-billing-app/src/billing-form/hie.resource.tsx
@@ -1,11 +1,13 @@
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
 
+type EligibilityResponse = { message: { eligible: 0 | 1; possible_solution: string; reason: string } };
+
 type HIEAPIResponse = {
   insurer: string;
   inforce: boolean;
   start: string;
-  end: string;
+  eligibility_response: EligibilityResponse;
 };
 
 export const useHIESubscription = (patientUuid: string) => {
@@ -15,7 +17,13 @@ export const useHIESubscription = (patientUuid: string) => {
   });
 
   return {
-    hieSubscriptions: data?.data ?? [],
+    data:
+      data?.data.map((d) => {
+        return {
+          ...d,
+          eligibility_response: JSON.parse(d.eligibility_response as unknown as string) as EligibilityResponse,
+        };
+      }) ?? [],
     isLoading,
     error,
     mutate,

--- a/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
+++ b/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { useTranslation } from 'react-i18next';
-import { Form, InlineNotification, Tooltip, InlineLoading } from '@carbon/react';
+import { ActionableNotification, Form, InlineLoading, InlineNotification, Tooltip } from '@carbon/react';
 import { CheckboxCheckedFilled, Information } from '@carbon/react/icons';
-import { useFormContext } from 'react-hook-form';
-import { formatDate, useConfig, usePatient } from '@openmrs/esm-framework';
-import { useHIESubscription } from '../hie.resource';
+import { formatDate, navigate, useConfig, usePatient } from '@openmrs/esm-framework';
 import capitalize from 'lodash-es/capitalize';
-import styles from './sha-number-validity.scss';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 import { BillingConfig } from '../../config-schema';
+import { useHIESubscription } from '../hie.resource';
+import styles from './sha-number-validity.scss';
 
 type SHANumberValidityProps = {
   paymentMethod: any;
@@ -28,6 +28,8 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
       identifier.type.coding.some((coding) => coding.code === nationalPatientUniqueIdentifierTypeUuid),
     );
 
+  const crNumber = undefined;
+
   if (!isSHA) {
     return null;
   }
@@ -35,6 +37,7 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
   if (isLoadingHIE || isLoading) {
     return <InlineLoading status="active" description={t('loading', 'Loading ...')} />;
   }
+
   if (error) {
     return (
       <InlineNotification
@@ -60,6 +63,21 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
           'patientMissingUniqueIdentifier',
           'Patient is missing National unique patient identifier, SHA validation cannot be done, Advise patient to visit registration desk',
         )}
+      />
+    );
+  }
+
+  if (!crNumber) {
+    return (
+      <ActionableNotification
+        title={t('pendingHIEVerification', 'Pending HIE verification')}
+        closeOnEscape
+        inline={false}
+        actionButtonLabel={t('verify', 'Verify')}
+        onActionButtonClick={() => {
+          navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/edit` });
+        }}
+        className={styles.missingCRNumber}
       />
     );
   }

--- a/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
+++ b/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
@@ -65,7 +65,7 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
         closeOnEscape
         inline={false}
         actionButtonLabel={t('verify', 'Verify')}
-        className={styles.missingCRNumber}
+        className={styles.missingSHANumber}
         onActionButtonClick={() => {
           navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/edit` });
         }}
@@ -81,7 +81,10 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
         closeOnEscape
         inline={false}
         actionButtonLabel={t('verify', 'Verify')}
-        className={styles.missingCRNumber}
+        className={styles.missingSHANumber}
+        onActionButtonClick={() => {
+          navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/edit` });
+        }}
       />
     );
   }

--- a/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
+++ b/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
@@ -1,7 +1,5 @@
-import { ActionableNotification, Form, InlineLoading, InlineNotification, Tooltip } from '@carbon/react';
-import { CheckboxCheckedFilled, Information } from '@carbon/react/icons';
-import { formatDate, navigate, useConfig, usePatient } from '@openmrs/esm-framework';
-import capitalize from 'lodash-es/capitalize';
+import { ActionableNotification, Form, InlineLoading, InlineNotification } from '@carbon/react';
+import { navigate, useConfig, usePatient } from '@openmrs/esm-framework';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -20,15 +18,13 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
   const { patient, isLoading } = usePatient(patientUuid);
   const { watch } = useFormContext();
   const isSHA = watch('insuranceScheme')?.includes('SHA');
-  const { hieSubscriptions, isLoading: isLoadingHIE, error } = useHIESubscription(patientUuid);
+  const { data, isLoading: isLoadingHIE, error } = useHIESubscription(patientUuid);
 
   const nationalUniquePatientIdentifier = patient?.identifier
     ?.filter((identifier) => identifier)
     .filter((identifier) =>
       identifier.type.coding.some((coding) => coding.code === nationalPatientUniqueIdentifierTypeUuid),
     );
-
-  const crNumber = undefined;
 
   if (!isSHA) {
     return null;
@@ -67,10 +63,11 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
     );
   }
 
-  if (!crNumber) {
+  if (data[0].eligibility_response.message.eligible === 0) {
     return (
       <ActionableNotification
         title={t('pendingHIEVerification', 'Pending HIE verification')}
+        subtitle={t('pendingVerificationReason', data[0].eligibility_response.message.reason)}
         closeOnEscape
         inline={false}
         actionButtonLabel={t('verify', 'Verify')}
@@ -84,7 +81,7 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
 
   return (
     <Form className={styles.formContainer}>
-      {hieSubscriptions?.map(({ inforce, insurer, start, end }, index) => {
+      {/* {hieSubscriptions?.map(({ inforce, insurer, start, end }, index) => {
         return (
           <div key={`${index}${insurer}`} className={styles.hieCard}>
             <div className={Boolean(inforce) ? styles.hieCardItemActive : styles.hieCardItemInActive}>
@@ -109,7 +106,7 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
             </div>
           </div>
         );
-      })}
+      })} */}
     </Form>
   );
 };

--- a/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
+++ b/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
@@ -31,7 +31,8 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
     ?.filter((identifier) => identifier)
     .filter((identifier) => identifier.type.coding.some((coding) => coding.code === shaIdentificationNumberUUID));
 
-  const hieEligibility = true;
+  // TODO correctly get eligibility from the backend
+  const isHIEEligible = true;
 
   if (!isSHA) {
     return null;
@@ -73,7 +74,7 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
     );
   }
 
-  if (!hieEligibility) {
+  if (!isHIEEligible) {
     return (
       <ActionableNotification
         title={t('pendingHIEVerification', 'Pending HIE verification')}

--- a/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.scss
+++ b/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.scss
@@ -67,3 +67,7 @@
   border: none;
   background-color: transparent;
 }
+
+.missingCRNumber{
+  max-width: unset;
+}

--- a/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.scss
+++ b/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.scss
@@ -68,6 +68,6 @@
   background-color: transparent;
 }
 
-.missingCRNumber{
+.missingSHANumber {
   max-width: unset;
 }

--- a/packages/esm-billing-app/src/config-schema.ts
+++ b/packages/esm-billing-app/src/config-schema.ts
@@ -16,17 +16,17 @@ export interface BillingConfig {
   billingStatusQueryUrl: string;
   mpesaAPIBaseUrl: string;
   insuranceSchemes: Array<string>;
-  nationalPatientUniqueIdentifierTypeUuid: string;
+  shaIdentificationNumberUUID: string;
   cashPointUuid: string;
   cashierUuid: string;
   patientBillsUrl: string;
 }
 
 export const configSchema = {
-  nationalPatientUniqueIdentifierTypeUuid: {
+  shaIdentificationNumberUUID: {
     _type: Type.String,
-    _description: 'The national unique patient identifier',
-    _default: 'f85081e2-b4be-4e48-b3a4-7994b69bb101',
+    _description: 'Social Health Authority Identification Number',
+    _default: '24aedd37-b5be-4e08-8311-3721b8d5100d',
   },
   inPatientVisitTypeUuid: {
     _type: Type.String,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR replaces the deprecated NUPI with SHA number. Also, its WIP to correctly get the HIE subscriptions from the backend.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
