### PR TITLE
(feat) KHP3-6945 : Add ability to capture reason for waiving bills

### DIFF
--- a/packages/esm-morgue-app/translations/en.json
+++ b/packages/esm-morgue-app/translations/en.json
@@ -12,6 +12,7 @@
   "fromHosp": "From Hospital",
   "morgue": "Morgue Management",
   "pullingCompartment": "Pulling compartments data.....",
+  "releaseBody": "Release body",
   "waitingQueue": "Waiting queue",
   "waitQueue": "Waiting queue"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR implements the initial functionality to capture and track reasons when waiving a bill. This is part of a larger feature set to enhance bill waiver management.

## Implementation Details
- Adds core infrastructure for bill waiver reason tracking

## Pending Tasks
To complete this feature, the following items need to be implemented:

1. Default Waiver Payment Attribute
   - Add functionality to capture waiver reasons during initialization
   - Implement following community precedent (reference: [OpenMRS Reference Application](https://github.com/alaboso/openmrs-distro-referenceapplication/blob/660efc67c4f2b00e3e08b40f81952377091b28d8/distro/configuration/paymentmodes/paymentModes.csv))

2. Payment Method Enhancement
   - Extend payment method functionality to handle all related properties and attributes
   - Implement full CRUD operations (Create, Read, Update, Delete)
   - Add support for attribute management per payment method


## Screenshots
https://github.com/user-attachments/assets/1211d47a-1ec2-4c08-b47f-81b6f586f4ac




## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
