### PR TITLE
(feat) KHP3-6963 : Add ability to add and edit full payment mode attributes

### DIFF
--- a/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill-form.workspace.tsx
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill-form.workspace.tsx
@@ -104,6 +104,7 @@ export const EditBillForm: React.FC<EditBillFormProps> = ({ lineItem, closeWorks
           name="price"
           render={({ field }) => (
             <ComboBox
+              id={`${field.name}-${field.value}`}
               onChange={({ selectedItem }) => {
                 if (selectedItem) {
                   setSelectedPrice(selectedItem?.price?.toString());
@@ -148,8 +149,8 @@ export const EditBillForm: React.FC<EditBillFormProps> = ({ lineItem, closeWorks
                 invalidText={errors.quantity?.message}
                 className={styles.formField}
                 min={1}
-                initialSelectedItem={field.value}
-                id="quantity"
+                value={field.value}
+                id={`${field.name}-${field.value}`}
                 hideSteppers
                 disableWheel
               />

--- a/packages/esm-billing-app/src/constants.ts
+++ b/packages/esm-billing-app/src/constants.ts
@@ -19,3 +19,4 @@ export const colorsArray = [
 
 // Size in MegaBits
 export const MAX_ALLOWED_FILE_SIZE = 2097152;
+export const PAYMENT_MODE_ATTRIBUTE_FORMATS = ['java.lang.String', 'java.lang.Integer', 'java.lang.Double'];

--- a/packages/esm-billing-app/src/metrics-cards/metrics-cards.component.tsx
+++ b/packages/esm-billing-app/src/metrics-cards/metrics-cards.component.tsx
@@ -36,7 +36,7 @@ export default function MetricsCards() {
     <div>
       <section className={styles.container}>
         {cards.map((card) => (
-          <Layer className={classNames(styles.cardContainer)}>
+          <Layer key={card.title} className={classNames(styles.cardContainer)}>
             <Tile className={styles.tileContainer}>
               <div className={styles.tileHeader}>
                 <div className={styles.headerLabelContainer}>

--- a/packages/esm-billing-app/src/payment-modes/payment-attributes/payment-mode-attributes.component.tsx
+++ b/packages/esm-billing-app/src/payment-modes/payment-attributes/payment-mode-attributes.component.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Controller, Control, useFormContext } from 'react-hook-form';
+import { ResponsiveWrapper } from '@openmrs/esm-framework';
+import { TextInput, Button, Dropdown, Toggle } from '@carbon/react';
+import styles from './payment-mode-attributes.scss';
+import { PAYMENT_MODE_ATTRIBUTE_FORMATS } from '../../constants';
+
+type PaymentModeAttributeFields = {
+  field: Record<string, any>;
+  index: number;
+  control: Control<Record<string, any>>;
+  removeAttributeType: (index: number) => void;
+  errors: Record<string, any>;
+};
+
+const PaymentModeAttributeFields: React.FC<PaymentModeAttributeFields> = ({
+  field,
+  index,
+  control,
+  removeAttributeType,
+  errors,
+}) => {
+  const { t } = useTranslation();
+  const { watch } = useFormContext();
+  const retired = watch(`attributeTypes.${index}.retired`);
+
+  return (
+    <div className={styles.paymentModeAttributes}>
+      <ResponsiveWrapper>
+        <Controller
+          control={control}
+          name={`attributeTypes.${index}.name`}
+          render={({ field }) => (
+            <TextInput
+              {...field}
+              labelText={t('attributeName', 'Attribute name')}
+              placeholder={t('enterAttributeName', 'Enter attribute name')}
+              invalid={!!errors?.attributeTypes?.[index]?.name}
+              invalidText={errors?.attributeTypes?.[index]?.name?.message}
+              id={`attributeTypes.${index}.name`}
+            />
+          )}
+        />
+      </ResponsiveWrapper>
+      <ResponsiveWrapper>
+        <Controller
+          control={control}
+          name={`attributeTypes.${index}.description`}
+          render={({ field }) => (
+            <TextInput
+              {...field}
+              labelText={t('attributeDescription', 'Attribute description')}
+              placeholder={t('enterAttributeDescription', 'Enter attribute description')}
+              invalid={!!errors?.attributeTypes?.[index]?.description}
+              invalidText={errors?.attributeTypes?.[index]?.description?.message}
+              id={`attributeTypes.${index}.description`}
+            />
+          )}
+        />
+      </ResponsiveWrapper>
+      <ResponsiveWrapper>
+        <Controller
+          control={control}
+          name={`attributeTypes.${index}.retired`}
+          render={({ field }) => (
+            <Toggle
+              {...field}
+              labelText={t('attributeRetired', 'Attribute retired')}
+              labelA="Off"
+              labelB="On"
+              toggled={field.value}
+              id={`attributeTypes.${index}.retired`}
+              onToggle={(value) => (value ? field.onChange(true) : field.onChange(false))}
+            />
+          )}
+        />
+      </ResponsiveWrapper>
+      {retired && (
+        <ResponsiveWrapper>
+          <Controller
+            control={control}
+            name={`attributeTypes.${index}.retiredReason`}
+            render={({ field }) => (
+              <TextInput
+                {...field}
+                labelText={t('attributeRetiredReason', 'Attribute retired reason')}
+                placeholder={t('enterAttributeRetiredReason', 'Enter attribute retired reason')}
+                invalid={!!errors?.attributeTypes?.[index]?.retiredReason}
+                invalidText={errors?.attributeTypes?.[index]?.retiredReason?.message}
+              />
+            )}
+          />
+        </ResponsiveWrapper>
+      )}
+      <ResponsiveWrapper>
+        <Controller
+          control={control}
+          name={`attributeTypes.${index}.format`}
+          render={({ field }) => (
+            <Dropdown
+              {...field}
+              id={`attributeTypes.${index}.format`}
+              titleText={t('attributeFormat', 'Attribute format')}
+              placeholder={t('selectAttributeFormat', 'Select attribute format')}
+              onChange={(event) => field.onChange(event.selectedItem)}
+              initialSelectedItem={field.value}
+              helperText={t('attributeFormatHelperText', 'The format of the attribute value e.g Free text, Number')}
+              items={PAYMENT_MODE_ATTRIBUTE_FORMATS}
+              invalid={!!errors?.attributeTypes?.[index]?.format}
+              invalidText={errors?.attributeTypes?.[index]?.format?.message}
+            />
+          )}
+        />
+      </ResponsiveWrapper>
+      <ResponsiveWrapper>
+        <Controller
+          control={control}
+          name={`attributeTypes.${index}.regExp`}
+          render={({ field }) => (
+            <TextInput
+              {...field}
+              labelText={t('regExp', 'Regular expression')}
+              placeholder={t('enterRegExp', 'Enter regular expression')}
+            />
+          )}
+        />
+      </ResponsiveWrapper>
+      <ResponsiveWrapper>
+        <Controller
+          control={control}
+          name={`attributeTypes.${index}.required`}
+          render={({ field }) => (
+            <Toggle
+              {...field}
+              labelText={t('attributeRequired', 'Attribute required')}
+              labelA="Off"
+              labelB="On"
+              toggled={field.value}
+              id={`attributeTypes.${index}.required`}
+              onToggle={(value) => (value ? field.onChange(true) : field.onChange(false))}
+            />
+          )}
+        />
+      </ResponsiveWrapper>
+      <Button size="sm" kind="danger--tertiary" onClick={() => removeAttributeType(index)}>
+        {t('remove', 'Remove')}
+      </Button>
+    </div>
+  );
+};
+
+export default PaymentModeAttributeFields;

--- a/packages/esm-billing-app/src/payment-modes/payment-attributes/payment-mode-attributes.scss
+++ b/packages/esm-billing-app/src/payment-modes/payment-attributes/payment-mode-attributes.scss
@@ -1,0 +1,10 @@
+@use '@carbon/layout';
+@use '@carbon/colors';
+
+.paymentModeAttributes {
+  display: flex;
+  flex-direction: column;
+  gap: layout.$spacing-05;
+  outline: 1px solid colors.$gray-10;
+  padding: layout.$spacing-05;
+}

--- a/packages/esm-billing-app/src/payment-modes/payment-mode-dashboard.scss
+++ b/packages/esm-billing-app/src/payment-modes/payment-mode-dashboard.scss
@@ -1,10 +1,32 @@
 @use '@carbon/layout';
 @use '@carbon/colors';
-
+@use '@carbon/type';
 .dataTable {
   margin: layout.$spacing-05;
 }
 
 .addPaymentModeButton {
   margin-right: layout.$spacing-05;
+}
+
+.attributeContainer {
+  background-color: colors.$gray-10;
+  padding: layout.$spacing-05;
+
+  .attributeCard {
+    display: grid;
+    grid-template-columns: layout.$layout-07 calc(layout.$layout-07 * 2);
+    gap: layout.$spacing-05;
+    row-gap: layout.$spacing-05;
+    padding: layout.$spacing-02;
+
+    .attributeLabel {
+      @include type.type-style('label-02');
+      color: colors.$gray-70;
+    }
+
+    .attributeValue {
+      @include type.type-style('legal-01');
+    }
+  }
 }

--- a/packages/esm-billing-app/src/payment-modes/payment-mode.workspace.test.tsx
+++ b/packages/esm-billing-app/src/payment-modes/payment-mode.workspace.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import PaymentModeWorkspace from './payment-mode.workspace';
 import userEvent from '@testing-library/user-event';
 import { createPaymentMode } from './payment-mode.resource';
@@ -20,6 +20,10 @@ jest.mock('./payment-mode.resource', () => ({
 }));
 
 describe('PaymentModeWorkspace', () => {
+  beforeEach(() => {
+    mockCreatePaymentMode.mockClear();
+  });
+
   test('should validate and submit correct form payload', async () => {
     const user = userEvent.setup();
     render(<PaymentModeWorkspace {...testProps} />);
@@ -30,19 +34,22 @@ describe('PaymentModeWorkspace', () => {
     await user.click(submitButton);
 
     // Should show validation error
-    expect(screen.getByText(/name is required/i)).toBeInTheDocument();
-    expect(screen.getByText(/description is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Payment mode name is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Payment mode description is required/i)).toBeInTheDocument();
 
     await user.type(nameInput, 'Test Name');
     await user.type(descriptionInput, 'Test Description');
     await user.click(submitButton);
 
     // should not show validation error
-    expect(screen.queryByText(/name is required/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/description is required/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Payment mode name is required/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Payment mode description is required/i)).not.toBeInTheDocument();
 
     // should call createPaymentMode
-    expect(mockCreatePaymentMode).toHaveBeenCalledWith({ description: 'Test Description', name: 'Test Name' }, '');
+    expect(mockCreatePaymentMode).toHaveBeenCalledWith(
+      { description: 'Test Description', name: 'Test Name', attributeTypes: [], retired: false },
+      '',
+    );
   });
 
   test('should show error message when submitting form fails', async () => {
@@ -70,5 +77,76 @@ describe('PaymentModeWorkspace', () => {
       kind: 'error',
       isLowContrast: true,
     });
+  });
+
+  test('should submit payload with attributeTypes', async () => {
+    const user = userEvent.setup();
+    render(<PaymentModeWorkspace {...testProps} />);
+
+    // key in name, description and retired
+    const nameInput = screen.getByRole('textbox', { name: /Payment mode name/i });
+    const descriptionInput = screen.getByRole('textbox', { name: /Payment mode description/i });
+    const retiredToggle = screen.getByRole('switch', { name: /Retired/i });
+
+    await user.type(nameInput, 'Test Name');
+    await user.type(descriptionInput, 'Test Description');
+    await user.click(retiredToggle);
+
+    // Click to add attribute type
+    const addAttributeTypeButton = screen.getByRole('button', { name: /Add attribute type/i });
+    await user.click(addAttributeTypeButton);
+
+    // Key in attribute type name, description, required and format
+    const attributeTypeNameInput = screen.getByRole('textbox', { name: /Attribute name/i });
+    const attributeTypeDescriptionInput = screen.getByRole('textbox', { name: /Attribute description/i });
+    const attributeRegExpInput = screen.getByRole('textbox', { name: /Enter regular expression/i });
+    const attributeRetiredToggle = screen.getByRole('switch', { name: /Attribute retired/i });
+    const attributeRequiredToggle = screen.getByRole('switch', { name: /Attribute required/i });
+    const attributeFormatDropdown = screen.getByRole('combobox', { name: /Attribute format/i });
+
+    // Key in attribute type details
+    await user.type(attributeTypeNameInput, 'Test Attribute Name');
+    await user.type(attributeTypeDescriptionInput, 'Test Attribute Description');
+    await user.type(attributeRegExpInput, 'Test Regular Expression');
+    await user.click(attributeRetiredToggle);
+    await user.click(attributeRequiredToggle);
+
+    // key retired reason
+    const attributeRetiredReasonInput = screen.getByRole('textbox', { name: /Retired reason/i });
+    await user.type(attributeRetiredReasonInput, 'Test Retired Reason');
+
+    // Click the dropdown to select format
+    const openDropdownButton = screen.getByRole('img', { name: /Open menu/i });
+    await user.click(openDropdownButton);
+
+    // Select the format
+    const formatOption = screen.getByText('java.lang.String');
+    await user.click(formatOption);
+
+    // Click save and close
+    const saveAndCloseButton = screen.getByRole('button', { name: /Save & Close/i });
+    await user.click(saveAndCloseButton);
+
+    // should call createPaymentMode with attributeTypes
+    expect(mockCreatePaymentMode).toHaveBeenCalledWith(
+      {
+        description: 'Test Description',
+        name: 'Test Name',
+        attributeTypes: [
+          {
+            name: 'Test Attribute Name',
+            description: 'Test Attribute Description',
+            retired: true,
+            required: true,
+            format: 'java.lang.String',
+            regExp: 'Test Regular Expression',
+            attributeOrder: 0,
+            foreignKey: null,
+          },
+        ],
+        retired: true,
+      },
+      '',
+    );
   });
 });

--- a/packages/esm-billing-app/src/payment-modes/usePaymentModeFormSchema.tsx
+++ b/packages/esm-billing-app/src/payment-modes/usePaymentModeFormSchema.tsx
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+const usePaymentModeFormSchema = () => {
+  const attributeTypeSchema = z
+    .object({
+      name: z.string(),
+      description: z.string(),
+      retired: z.boolean().default(false),
+      retiredReason: z.string().optional(),
+      format: z.string().optional(),
+      regExp: z.string().optional(),
+      required: z.boolean().default(false),
+    })
+    .refine(
+      (data) => {
+        if (data.retired === true) {
+          return !!data.retiredReason && data.retiredReason.trim().length > 0;
+        }
+        return true;
+      },
+      {
+        message: 'Retired reason is required when attribute type is retired',
+        path: ['retiredReason'],
+      },
+    );
+
+  const paymentModeFormSchema = z.object({
+    name: z
+      .string({
+        required_error: 'Payment mode name is required',
+        invalid_type_error: 'Payment mode name is required',
+      })
+      .min(1, 'Payment mode name is required'),
+    description: z
+      .string({
+        required_error: 'Payment mode description is required',
+        invalid_type_error: 'Payment mode description is required',
+      })
+      .min(1, 'Payment mode description is required'),
+    retired: z
+      .boolean({
+        invalid_type_error: 'Retired must be a boolean',
+      })
+      .optional()
+      .default(false), // Provides a default value if retired is not specified
+    attributeTypes: z.array(attributeTypeSchema).optional(),
+  });
+
+  return { paymentModeFormSchema };
+};
+
+export default usePaymentModeFormSchema;

--- a/packages/esm-billing-app/src/types/index.ts
+++ b/packages/esm-billing-app/src/types/index.ts
@@ -87,14 +87,14 @@ export interface Patient {
 }
 
 interface AttributeType {
-  uuid: string;
+  uuid?: string;
   name: string;
   description: string;
   retired: boolean;
-  attributeOrder: number;
-  format: string;
-  foreignKey: string | null;
-  regExp: string | null;
+  attributeOrder?: number;
+  format?: string;
+  foreignKey?: string | null;
+  regExp?: string | null;
   required: boolean;
 }
 
@@ -478,15 +478,15 @@ export type ExcelFileRow = {
 };
 
 export type PaymentMode = {
-  uuid: string;
+  uuid?: string;
   name: string;
   description: string;
   retired: boolean;
-  retireReason?: string | null;
-  auditInfo: AuditInfo;
+  retiredReason?: string | null;
+  auditInfo?: AuditInfo;
   attributeTypes?: Array<AttributeType>;
   sortOrder?: number | null;
-  resourceVersion: string;
+  resourceVersion?: string;
 };
 
 export type SHAIntervension = {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This is the second part to having payment attributes work correctly. Its a follow up PR to [KHP3-6945](https://github.com/palladiumkenya/kenyaemr-esm-3.x/pull/426). This PR adds ability to define edit and delete payment attributes. We should be able to add reference to any payment made when the reference is available.

## Screenshots
![Kapture 2024-10-29 at 16 46 15](https://github.com/user-attachments/assets/ca045417-b3d9-460d-8b6f-e8c629fdf6e3)


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->


[KHP3-6945]: https://thepalladiumgroup.atlassian.net/browse/KHP3-6945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ