### PR TITLE
(refactor) :   Standardize padding in patient claims page

### DIFF
--- a/packages/esm-billing-app/src/claims/claims-wrap/claims-main.scss
+++ b/packages/esm-billing-app/src/claims/claims-wrap/claims-main.scss
@@ -1,3 +1,5 @@
+@use '@carbon/layout';
+
 .mainContainer {
   display: flex;
   margin: 0 auto;
@@ -7,6 +9,7 @@
 .content {
   display: flex;
   width: 100%;
+  gap: layout.$spacing-05;
 }
 
 :global(.omrs-breakpoint-lt-desktop) {

--- a/packages/esm-billing-app/src/claims/dashboard/form/claims-form.scss
+++ b/packages/esm-billing-app/src/claims/dashboard/form/claims-form.scss
@@ -21,7 +21,6 @@
 
 .form {
   width: 100%;
-  margin: layout.$spacing-09 layout.$spacing-05 0;
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/packages/esm-billing-app/src/claims/dashboard/table/claims-table.component.tsx
+++ b/packages/esm-billing-app/src/claims/dashboard/table/claims-table.component.tsx
@@ -1,10 +1,8 @@
-import React, { useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import fuzzy from 'fuzzy';
 import {
   DataTable,
   DataTableSkeleton,
   Layer,
+  Pagination,
   Table,
   TableBody,
   TableCell,
@@ -12,18 +10,20 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableSelectRow,
   TableToolbar,
   TableToolbarContent,
   TableToolbarSearch,
-  TableSelectRow,
   Tile,
-  Pagination,
   type DataTableHeader,
   type DataTableRow,
 } from '@carbon/react';
 import { formatDate, isDesktop, useDebounce, useLayoutType } from '@openmrs/esm-framework';
-import styles from './claims-table.scss';
+import fuzzy from 'fuzzy';
+import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { LineItem, MappedBill } from '../../../types';
+import styles from './claims-table.scss';
 
 type ClaimsTableProps = {
   bill: MappedBill;
@@ -191,20 +191,22 @@ const ClaimsTable: React.FC<ClaimsTableProps> = ({ bill, isSelectable = true, is
           </Layer>
         </div>
       )}
-      <Pagination
-        forwardText="Next page"
-        backwardText="Previous page"
-        page={currentPage}
-        pageSize={pageSize}
-        pageSizes={[5, 10, 20, 50]}
-        totalItems={filteredLineItems.length}
-        className={styles.pagination}
-        size={responsiveSize}
-        onChange={({ pageSize: newPageSize, page: newPage }) => {
-          setPageSize(newPageSize);
-          setCurrentPage(newPage);
-        }}
-      />
+      {tableRows.length > pageSize && (
+        <Pagination
+          forwardText="Next page"
+          backwardText="Previous page"
+          page={currentPage}
+          pageSize={pageSize}
+          pageSizes={[5, 10, 20, 50]}
+          totalItems={filteredLineItems.length}
+          className={styles.pagination}
+          size={responsiveSize}
+          onChange={({ pageSize: newPageSize, page: newPage }) => {
+            setPageSize(newPageSize);
+            setCurrentPage(newPage);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/packages/esm-billing-app/src/claims/dashboard/table/claims-table.scss
+++ b/packages/esm-billing-app/src/claims/dashboard/table/claims-table.scss
@@ -33,8 +33,6 @@
 
 .claimContainer {
   width: 100%;
-  margin: layout.$spacing-09 layout.$spacing-05 0;
-  border: 1px solid $ui-03;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;

--- a/packages/esm-billing-app/src/claims/metrics/metrics-card.scss
+++ b/packages/esm-billing-app/src/claims/metrics/metrics-card.scss
@@ -16,7 +16,6 @@
   border: 0.0625rem solid $ui-03;
   height: 7.875rem;
   padding: spacing.$spacing-05;
-  margin: spacing.$spacing-03 spacing.$spacing-03;
 }
 
 .tileHeader {

--- a/packages/esm-billing-app/src/claims/metrics/metrics.scss
+++ b/packages/esm-billing-app/src/claims/metrics/metrics.scss
@@ -1,10 +1,13 @@
 @use '@carbon/styles/scss/spacing';
 @use '@openmrs/esm-styleguide/src/vars' as *;
+@use '@carbon/layout';
 
 .cardContainer {
   display: flex;
   justify-content: space-between;
-  padding: 0 spacing.$spacing-05 spacing.$spacing-07 spacing.$spacing-03;
+  gap: layout.$spacing-05;
   flex-flow: row wrap;
   margin-top: -(spacing.$spacing-03);
+  margin-bottom: layout.$spacing-05;
+  padding: layout.$spacing-05;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR fixes a simple layout issue to provide consistent padding and alignment on the patient claim page. Just a UX fix nothing major.

## Screenshots
![image](https://github.com/user-attachments/assets/b8a87777-cfcd-4507-8e2c-8c82b0a28af9)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
