### PR TITLE
(feat) KHP3-6945 : Enhance waiving to support multiple waivers

### DIFF
--- a/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/waive-bill/waive-bill-form.scss
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/waive-bill/waive-bill-form.scss
@@ -1,10 +1,6 @@
 @use '@carbon/layout';
 @use '@carbon/type';
-@use '@carbon/styles/scss/spacing';
-
-.form {
-  padding: layout.$spacing-05;
-}
+@use '@carbon/colors';
 
 .buttonContainer {
   display: flex;
@@ -18,7 +14,7 @@
 
 .billWaiverDescription {
   display: grid;
-  grid-template-columns: 5rem 1fr;
+  grid-template-columns: 1fr 1fr;
   column-gap: 1rem;
   align-items: center;
   margin-top: 0.125rem;
@@ -34,5 +30,28 @@
 }
 
 .editFormInput {
-  margin-bottom: spacing.$spacing-05;
+  margin-bottom: layout.$spacing-05;
+}
+.waiverPaymentModeNotFound {
+  margin: layout.$spacing-03;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.formContainer {
+  margin: layout.$spacing-05;
+}
+
+.tablet {
+  padding: layout.$spacing-06 layout.$spacing-05;
+  background-color: colors.$white;
+}
+
+.desktop {
+  padding: 0;
 }

--- a/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/waive-bill/waive-bill-form.test.tsx
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/waive-bill/waive-bill-form.test.tsx
@@ -15,11 +15,6 @@ jest.mock('../../../../billing.resource', () => ({
   usePaymentModes: jest.fn(),
 }));
 
-jest.mock('@openmrs/esm-framework', () => ({
-  closeWorkspace: jest.fn(),
-  showSnackbar: jest.fn(),
-}));
-
 const mockedBill: MappedBill = {
   id: 1909,
   uuid: '45143fae-b83d-4768-ada5-621e8dc1229d',

--- a/packages/esm-billing-app/src/billing.resource.ts
+++ b/packages/esm-billing-app/src/billing.resource.ts
@@ -3,6 +3,7 @@ import {
   openmrsFetch,
   OpenmrsResource,
   parseDate,
+  restBaseUrl,
   useConfig,
   useSession,
   useVisit,
@@ -68,7 +69,7 @@ export const useBills = (
   const startingDateISO = startingDate.toISOString();
   const endDateISO = endDate.toISOString();
 
-  const url = `/ws/rest/v1/cashier/bill?status=${billStatus}&v=custom:(uuid,display,voided,voidReason,adjustedBy,cashPoint:(uuid,name),cashier:(uuid,display),dateCreated,lineItems,patient:(uuid,display))&createdOnOrAfter=${startingDateISO}&createdOnOrBefore=${endDateISO}`;
+  const url = `${restBaseUrl}/cashier/bill?status=${billStatus}&v=custom:(uuid,display,voided,voidReason,adjustedBy,cashPoint:(uuid,name),cashier:(uuid,display),dateCreated,lineItems,patient:(uuid,display))&createdOnOrAfter=${startingDateISO}&createdOnOrBefore=${endDateISO}`;
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<PatientInvoice> } }>(
     patientUuid ? `${url}&patientUuid=${patientUuid}` : url,
@@ -94,7 +95,7 @@ export const useBills = (
 };
 
 export const useBill = (billUuid: string) => {
-  const url = `/ws/rest/v1/cashier/bill/${billUuid}`;
+  const url = `${restBaseUrl}/cashier/bill/${billUuid}`;
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: PatientInvoice }>(
     billUuid ? url : null,
     openmrsFetch,
@@ -146,7 +147,7 @@ export const useBill = (billUuid: string) => {
 };
 
 export const processBillPayment = (payload, billUuid: string) => {
-  const url = `/ws/rest/v1/cashier/bill/${billUuid}`;
+  const url = `${restBaseUrl}/cashier/bill/${billUuid}`;
   return openmrsFetch(url, {
     method: 'POST',
     body: payload,
@@ -158,7 +159,7 @@ export const processBillPayment = (payload, billUuid: string) => {
 
 export function useDefaultFacility() {
   const { authenticated } = useSession();
-  const url = '/ws/rest/v1/kenyaemr/default-facility';
+  const url = '${restBaseUrl}/kenyaemr/default-facility';
   const { data, isLoading } = useSWR<{ data: FacilityDetail }>(authenticated ? url : null, openmrsFetch, {});
   return { data: data?.data, isLoading: isLoading };
 }
@@ -166,9 +167,9 @@ export function useDefaultFacility() {
 export function useFetchSearchResults(searchVal, category) {
   let url = ``;
   if (category == 'Stock Item') {
-    url = `/ws/rest/v1/stockmanagement/stockitem?v=default&limit=10&q=${searchVal}`;
+    url = `${restBaseUrl}/stockmanagement/stockitem?v=default&limit=10&q=${searchVal}`;
   } else {
-    url = `/ws/rest/v1/cashier/billableService?v=custom:(uuid,name,shortName,serviceStatus,serviceType:(display),servicePrices:(uuid,name,price,paymentMode))`;
+    url = `${restBaseUrl}/cashier/billableService?v=custom:(uuid,name,shortName,serviceStatus,serviceType:(display),servicePrices:(uuid,name,price,paymentMode))`;
   }
   const { data, error, isLoading, isValidating } = useSWR(searchVal ? url : null, openmrsFetch, {});
 
@@ -189,7 +190,7 @@ export const usePatientPaymentInfo = (patientUuid: string) => {
 };
 
 export const processBillItems = (payload) => {
-  const url = `/ws/rest/v1/cashier/bill`;
+  const url = `${restBaseUrl}/cashier/bill`;
   return openmrsFetch(url, {
     method: 'POST',
     body: payload,
@@ -201,7 +202,7 @@ export const processBillItems = (payload) => {
 
 export const usePaymentModes = (excludeWaiver: boolean = true) => {
   const { excludedPaymentMode } = useConfig<BillingConfig>();
-  const url = `/ws/rest/v1/cashier/paymentMode?v=full`;
+  const url = `${restBaseUrl}/cashier/paymentMode?v=full`;
   const { data, isLoading, error, mutate } = useSWR<{ data: { results: Array<PaymentMethod> } }>(url, openmrsFetch, {
     errorRetryCount: 2,
   });
@@ -218,7 +219,7 @@ export const usePaymentModes = (excludeWaiver: boolean = true) => {
 };
 
 export const useBillableItems = () => {
-  const url = `/ws/rest/v1/cashier/billableService?v=custom:(uuid,name,shortName,serviceStatus,serviceType:(display),servicePrices:(uuid,name,price,paymentMode))`;
+  const url = `${restBaseUrl}/cashier/billableService?v=custom:(uuid,name,shortName,serviceStatus,serviceType:(display),servicePrices:(uuid,name,price,paymentMode))`;
   const { data, isLoading, error } = useSWR<{ data: { results: Array<OpenmrsResource> } }>(url, openmrsFetch);
   const [searchTerm, setSearchTerm] = useState('');
   const filteredItems =
@@ -232,19 +233,19 @@ export const useBillableItems = () => {
   };
 };
 export const useCashPoint = () => {
-  const url = `/ws/rest/v1/cashier/cashPoint`;
+  const url = `${restBaseUrl}/cashier/cashPoint`;
   const { data, isLoading, error } = useSWR<{ data: { results: Array<OpenmrsResource> } }>(url, openmrsFetch);
 
   return { isLoading, error, cashPoints: data?.data?.results ?? [] };
 };
 
 export const createPatientBill = (payload) => {
-  const postUrl = `/ws/rest/v1/cashier/bill`;
+  const postUrl = `${restBaseUrl}/cashier/bill`;
   return openmrsFetch(postUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: payload });
 };
 
 export const useConceptAnswers = (conceptUuid: string) => {
-  const url = `/ws/rest/v1/concept/${conceptUuid}`;
+  const url = `${restBaseUrl}/concept/${conceptUuid}`;
   const { data, isLoading, error } = useSWR<{ data: { answers: Array<OpenmrsResource> } }>(url, openmrsFetch);
   return { conceptAnswers: data?.data?.answers, isLoading, error };
 };

--- a/packages/esm-billing-app/src/payment-modes/payment-mode-dashboard.compont.tsx
+++ b/packages/esm-billing-app/src/payment-modes/payment-mode-dashboard.compont.tsx
@@ -31,7 +31,7 @@ type PaymentModeDashboardProps = {};
 const PaymentModeDashboard: React.FC<PaymentModeDashboardProps> = () => {
   const { t } = useTranslation();
   const size = 'md';
-  const { paymentModes, isLoading } = usePaymentModes();
+  const { paymentModes = [], isLoading } = usePaymentModes(false);
   const [searchTerm, setSearchTerm] = useState('');
 
   const debouncedSearchTerm = useDebounce(searchTerm, 500);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR introduces two key improvements to the waiver system:

1. Improved Error Handling
   - Added validation for waiver reason payment attribute configuration
   - Displays clear error message to administrators when the attribute is missing

2. Multiple Waiver Support
   - Implemented ability to apply multiple waivers to a single bill
   - Resolves limitation reported at Kayole where only one waiver could be applied


## Screenshots
[Kapture 2024-11-07 at 09.31.53.webm](https://github.com/user-attachments/assets/7356e367-47e6-4d06-984e-0022f49b60df)

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
