### PR TITLE
(fix) : prevent undefined errors by using correct payment endpoint

### DIFF
--- a/packages/esm-billing-app/src/payment-points/payment-point/clock-in.component.tsx
+++ b/packages/esm-billing-app/src/payment-points/payment-point/clock-in.component.tsx
@@ -46,11 +46,12 @@ export const ClockIn = ({ closeModal, paymentPoint }: { closeModal: () => void; 
   });
 
   const clockInWrapper = (paymentPointUUID: string) => {
+    const selectedPaymentPoint = paymentPoints.find((point) => point.uuid === paymentPointUUID);
     clockIn({ cashier: providerUUID, cashPoint: paymentPointUUID, clockIn: new Date().toISOString() })
       .then(() => {
         showSnackbar({
           title: t('success', 'Success'),
-          subtitle: t('successfullyClockedIn', `Successfully Clocked In ${paymentPoint.name}`),
+          subtitle: t('successfullyClockedIn', `Successfully Clocked In ${selectedPaymentPoint.name}`),
           kind: 'success',
         });
         mutate();
@@ -59,7 +60,7 @@ export const ClockIn = ({ closeModal, paymentPoint }: { closeModal: () => void; 
       .catch(() => {
         showSnackbar({
           title: t('anErrorOccurred', 'An Error Occurred'),
-          subtitle: t('anErrorOccurredClockingIn', `An error occurred clocking in ${paymentPoint.name}`),
+          subtitle: t('anErrorOccurredClockingIn', `An error occurred clocking in ${selectedPaymentPoint.name}`),
           kind: 'error',
         });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR fixes the clock-in bug that the clock-in modal did not close even on success. The gist is I wasn`t checking for undefined on the payment point.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
