### PR TITLE
fix: settle bills on correct cash point

### DIFF
--- a/__mocks__/bills.mock.ts
+++ b/__mocks__/bills.mock.ts
@@ -662,3 +662,57 @@ export const mockPaymentModes = [
   },
   { uuid: 'eb6173cb-9678-4614-bbe1-0ccf7ed9d1d4', name: 'Waiver', description: 'Waiver payment', retired: false },
 ];
+
+export const mockedActiveSheet = {
+  uuid: 'cbf56e9a-5db1-41d3-8d34-e228aa2e31c0',
+  display: '14 Nov 2024, 08:11 to  open',
+  voided: false,
+  voidReason: null,
+  auditInfo: {
+    creator: {
+      uuid: 'e02c40e5-04e7-11e5-ae3c-a0b3cc4f922f',
+      display: 'admin',
+      links: [
+        {
+          rel: 'self',
+          uri: 'http://dev.kenyahmis.org/openmrs/ws/rest/v1/user/e02c40e5-04e7-11e5-ae3c-a0b3cc4f922f',
+          resourceAlias: 'user',
+        },
+      ],
+    },
+    dateCreated: '2024-11-14T08:11:27.000+0300',
+    changedBy: null,
+    dateChanged: null,
+  },
+  cashier: {
+    uuid: '48b55692-e061-4ffa-b1f2-fd4aaf506224',
+    display: 'admin - Barbara Stewart Lopez',
+    links: [
+      {
+        rel: 'self',
+        uri: 'http://dev.kenyahmis.org/openmrs/ws/rest/v1/provider/48b55692-e061-4ffa-b1f2-fd4aaf506224',
+        resourceAlias: 'provider',
+      },
+    ],
+  },
+  cashPoint: {
+    uuid: '65dd568e-4124-4e89-a4f8-0b07c58ec6fe',
+    name: 'MNCH Pay Point',
+    description: 'Payment done at the MNCH department',
+    retired: false,
+    location: {
+      uuid: '233de33e-2778-4f9a-a398-fa09da9daa14',
+      display: 'Wamagana Health Centre',
+      links: [
+        {
+          rel: 'self',
+          uri: 'http://dev.kenyahmis.org/openmrs/ws/rest/v1/location/233de33e-2778-4f9a-a398-fa09da9daa14',
+          resourceAlias: 'location',
+        },
+      ],
+    },
+  },
+  clockIn: '2024-11-14T08:11:27.000+0300',
+  clockOut: null,
+  resourceVersion: '1.8',
+};

--- a/packages/esm-billing-app/src/hooks/useRequestStatus.tsx
+++ b/packages/esm-billing-app/src/hooks/useRequestStatus.tsx
@@ -6,7 +6,8 @@ import { processBillPayment, usePaymentModes } from '../billing.resource';
 import { BillingConfig } from '../config-schema';
 import { processBillItem } from '../invoice/payments/utils';
 import { getErrorMessage, getRequestStatus, readableStatusMap } from '../m-pesa/mpesa-resource';
-import { LineItem, MappedBill, PaymentStatus, RequestStatus } from '../types';
+import { useClockInStatus } from '../payment-points/use-clock-in-status';
+import { LineItem, MappedBill, PaymentStatus, RequestStatus, Timesheet } from '../types';
 import { extractErrorMessagesFromResponse, waitForASecond } from '../utils';
 
 export const createMobileMoneyPaymentPayload = (
@@ -14,6 +15,7 @@ export const createMobileMoneyPaymentPayload = (
   amount: number,
   mobileMoneyInstanceTypeUUID: string,
   paymentReference: { uuid: string; value: string },
+  timesheet?: Timesheet,
 ) => {
   const { cashier } = bill;
   const totalAmount = bill?.totalAmount;
@@ -72,7 +74,7 @@ export const createMobileMoneyPaymentPayload = (
     : PaymentStatus.PAID;
 
   const processedPayment = {
-    cashPoint: bill.cashPointUuid,
+    cashPoint: timesheet ? timesheet.cashPoint.uuid : bill.cashPointUuid,
     cashier: cashier.uuid,
     lineItems: updatedLineItems,
     payments: updatedPayments,
@@ -112,6 +114,8 @@ export const useRequestStatus = (
     amount: null,
   });
 
+  const { globalActiveSheet } = useClockInStatus();
+
   useEffect(() => {
     let interval: NodeJS.Timeout;
 
@@ -139,6 +143,7 @@ export const useRequestStatus = (
               parseInt(requestData.amount),
               mobileMoneyPaymentMethodInstanceTypeUUID,
               { uuid: paymentReferenceUUID, value: referenceCode },
+              globalActiveSheet,
             );
 
             processBillPayment(mobileMoneyPayload, bill.uuid).then(
@@ -199,6 +204,7 @@ export const useRequestStatus = (
     setNotification,
     t,
     isPDSLFacility,
+    globalActiveSheet,
   ]);
 
   return [requestData, setRequestData];

--- a/packages/esm-billing-app/src/invoice/payments/utils.ts
+++ b/packages/esm-billing-app/src/invoice/payments/utils.ts
@@ -1,4 +1,4 @@
-import { FormPayment, LineItem, MappedBill } from '../../types';
+import { FormPayment, LineItem, MappedBill, Timesheet } from '../../types';
 
 export const hasLineItem = (lineItems: Array<LineItem>, item: LineItem) => {
   if (lineItems?.length === 0) {
@@ -14,6 +14,7 @@ export const createPaymentPayload = (
   formValues: Array<FormPayment>,
   amountDue: number,
   selectedLineItems: Array<LineItem>,
+  timesheet: Timesheet,
 ) => {
   const { cashier } = bill;
   const totalAmount = bill?.totalAmount;
@@ -51,7 +52,7 @@ export const createPaymentPayload = (
     updatedLineItems.filter((item) => item.paymentStatus === 'PENDING').length === 0 ? 'PAID' : 'PENDING';
 
   const processedPayment = {
-    cashPoint: bill.cashPointUuid,
+    cashPoint: timesheet.cashPoint.uuid,
     cashier: cashier.uuid,
     lineItems: updatedLineItems,
     payments: [...updatedPayments],

--- a/packages/esm-billing-app/src/invoice/payments/utils.ts
+++ b/packages/esm-billing-app/src/invoice/payments/utils.ts
@@ -52,7 +52,7 @@ export const createPaymentPayload = (
     updatedLineItems.filter((item) => item.paymentStatus === 'PENDING').length === 0 ? 'PAID' : 'PENDING';
 
   const processedPayment = {
-    cashPoint: timesheet.cashPoint.uuid,
+    cashPoint: timesheet?.cashPoint?.uuid,
     cashier: cashier.uuid,
     lineItems: updatedLineItems,
     payments: [...updatedPayments],


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR adds a way to settle a bill at the correct cash point. Previously it was assumed that where you create the bill is where it's settled.

## Screenshots
### An example of settling a bill at a 'non-default' payment point.
![image](https://github.com/user-attachments/assets/55eebb6c-7ad3-4221-a2fc-0cc1bd583710)

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
