### PR TITLE
(fix) : fix regression on `pick-procedure` action button

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/test-order/test-order-action.component.tsx
@@ -89,9 +89,9 @@ const TestOrderAction: React.FC<TestOrderProps> = React.memo((props) => {
 
   const buttonText = hasPendingPayment
     ? t('unsettledBill', 'Unsettled bill.')
-    : actionText ?? Object.hasOwn(props, 'medicationRequestBundle')
-    ? t('dispense', 'Dispense')
-    : t('pickLabRequest', 'Pick Lab Request');
+    : Object.hasOwn(props, 'medicationRequestBundle')
+    ? actionText ?? t('dispense', 'Dispense')
+    : actionText ?? t('pickLabRequest', 'Pick Lab Request');
 
   return (
     <Button kind="primary" disabled={hasPendingPayment} key={`${orderUuid}`} onClick={launchModal}>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Fix: Restore correct label text for pick-procedure component that was accidentally replaced with 'dispense' in PR #456

## Screenshots
<img width="1466" alt="Screenshot 2024-11-14 at 19 09 43" src="https://github.com/user-attachments/assets/25cc1c82-1702-449c-a393-a7a46ee5628b">



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
