### PR TITLE
(fix) : allow bill manager to modify bills beyond 24-hour limit

### DIFF
--- a/packages/esm-billing-app/src/billable-services/bill-manager/bill-manager.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/bill-manager.component.tsx
@@ -3,11 +3,11 @@ import { ExtensionSlot, UserHasAccess, WorkspaceContainer } from '@openmrs/esm-f
 import PatientBills from './patient-bills.component';
 import styles from './bill-manager.scss';
 import billTableStyles from '../../bills-table/bills-table.scss';
-import { useBills } from '../../billing.resource';
-import { DataTableSkeleton, Layer, Tile } from '@carbon/react';
-import { EmptyDataIllustration, EmptyState } from '@openmrs/esm-patient-common-lib';
+import { DataTableSkeleton } from '@carbon/react';
+import { EmptyState } from '@openmrs/esm-patient-common-lib';
 import { useTranslation } from 'react-i18next';
 import BillingHeader from '../../billing-header/billing-header.component';
+import { usePatientBills } from '../../modal/require-payment.resource';
 
 type BillManagerProps = {};
 
@@ -21,7 +21,7 @@ const BillManager: React.FC<BillManagerProps> = () => {
   const [patientUuid, setPatientUuid] = React.useState<string>(undefined);
   const { t } = useTranslation();
 
-  const { bills, isLoading } = useBills(patientUuid);
+  const { patientBills: bills, isLoading } = usePatientBills(patientUuid);
   const filteredBills =
     bills.filter((bill) => !Boolean(bill.totalAmount === bill.tenderedAmount) && patientUuid === bill.patientUuid) ??
     [];

--- a/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/cancel-bill/cancel-bill.workspace.tsx
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/cancel-bill/cancel-bill.workspace.tsx
@@ -64,7 +64,7 @@ const CancelBillWorkspace: React.FC<CancelBillWorkspaceProps> = ({
         });
       }
       // mutate the bill
-      mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/cashier/bill?status`), undefined, {
+      mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/cashier/bill`), undefined, {
         revalidate: true,
       });
       closeWorkspaceWithSavedChanges();

--- a/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill/edit-bill-form.workspace.tsx
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill/edit-bill-form.workspace.tsx
@@ -82,7 +82,7 @@ export const EditBillForm: React.FC<EditBillFormProps> = ({
         timeoutInMs: 5000,
       });
     } finally {
-      mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/cashier/bill?status`), undefined, {
+      mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/cashier/bill`), undefined, {
         revalidate: true,
       });
       closeWorkspaceWithSavedChanges();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Previously, bill managers were unable to edit, delete, or waive bills that were older than 24 hours, limiting their ability to handle historical billing issues. This restriction has been removed to enable full bill management capabilities regardless of bill age.
- Added mutations for respective actions on delete/edit/cancel actions
## Screenshots
[Kapture 2024-11-15 at 00.24.58.webm](https://github.com/user-attachments/assets/5e529405-2922-44cd-a9e3-1fdb36b069cb)


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
