### PR TITLE
fix: check for null line item before accessing voided property

### DIFF
--- a/packages/esm-billing-app/src/billing.resource.ts
+++ b/packages/esm-billing-app/src/billing.resource.ts
@@ -34,7 +34,7 @@ export const mapBillProperties = (bill: PatientInvoice): MappedBill => {
     cashPointLocation: bill?.cashPoint?.location?.display,
     dateCreated: bill?.dateCreated ? formatDate(parseDate(bill.dateCreated), { mode: 'wide' }) : '--',
     dateCreatedUnformatted: bill.dateCreated,
-    lineItems: bill.lineItems.filter((li) => !li.voided),
+    lineItems: bill.lineItems.filter((li) => (li ? !li.voided : true)),
     billingService: extractString(bill.lineItems.map((bill) => bill.item || bill.billableService || '--').join('  ')),
     payments: bill.payments,
     display: bill.display,

--- a/packages/esm-billing-app/src/billing.resource.ts
+++ b/packages/esm-billing-app/src/billing.resource.ts
@@ -138,7 +138,7 @@ export const useBill = (billUuid: string) => {
   // filter out voided line items to prevent them from being included in the bill
   // TODO: add backend support for voided line items
   // https://thepalladiumgroup.atlassian.net/browse/KHP3-7068
-  const filteredLineItems = data?.data?.lineItems?.filter((li) => !li.voided) ?? [];
+  const filteredLineItems = data?.data?.lineItems?.filter((li) => (li ? li.voided : true)) ?? [];
   const formattedBill = data?.data
     ? mapBillProperties({ ...data?.data, lineItems: filteredLineItems })
     : ({} as MappedBill);

--- a/packages/esm-billing-app/src/billing.resource.ts
+++ b/packages/esm-billing-app/src/billing.resource.ts
@@ -138,7 +138,7 @@ export const useBill = (billUuid: string) => {
   // filter out voided line items to prevent them from being included in the bill
   // TODO: add backend support for voided line items
   // https://thepalladiumgroup.atlassian.net/browse/KHP3-7068
-  const filteredLineItems = data?.data?.lineItems?.filter((li) => (li ? li.voided : true)) ?? [];
+  const filteredLineItems = data?.data?.lineItems?.filter((li) => (li ? !li.voided : true)) ?? [];
   const formattedBill = data?.data
     ? mapBillProperties({ ...data?.data, lineItems: filteredLineItems })
     : ({} as MappedBill);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR makes a simple fix to check for a null line item before accessing its voided property to prevent null pointer errors.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
