### PR TITLE
(fix): disable fetch call when patient is undefined

### DIFF
--- a/packages/esm-billing-app/src/prompt-payment/prompt-payment.resource.tsx
+++ b/packages/esm-billing-app/src/prompt-payment/prompt-payment.resource.tsx
@@ -125,21 +125,22 @@ export const useBillingPrompt = (
   };
 };
 
-/*
- Custom hook to fetch patient bills
- @param patientUuid - The UUID of the patient
- @returns {
-    patientBills: Array<PatientInvoice>,
-    isLoading: boolean,
-    error: Error,
-    isValidating: boolean,
-    mutate: () => void
- }
-*/
+/**
+ * Custom hook to fetch patient bills.
+ *
+ * @param {string} patientUuid - The UUID of the patient.
+ * @returns {Object} The response object containing patient bills and hook states.
+ * @returns {Array<PatientInvoice>} [returns.patientBills] - An array of patient invoices.
+ * @returns {boolean} [returns.isLoading] - Whether the data is currently being loaded.
+ * @returns {Error|null} [returns.error] - Any error that occurred during the fetch, or null if none.
+ * @returns {boolean} [returns.isValidating] - Whether the data is being revalidated.
+ * @returns {Function} [returns.mutate] - A function to manually trigger a re-fetch of the data.
+ */
 export const usePatientBills = (patientUuid: string) => {
   const { patientBillsUrl } = useConfig<BillingConfig>();
   const url = patientBillsUrl.replace('${restBaseUrl}', restBaseUrl);
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<PatientInvoice> } }>(
+    // a null key in useSWR essentially disables the fetch call until a patientUUID is available
     patientUuid ? `${url}&patientUuid=${patientUuid}&includeVoided=true` : null,
     openmrsFetch,
     {

--- a/packages/esm-billing-app/src/prompt-payment/prompt-payment.resource.tsx
+++ b/packages/esm-billing-app/src/prompt-payment/prompt-payment.resource.tsx
@@ -1,9 +1,9 @@
 import { Visit, openmrsFetch, restBaseUrl, useConfig, useVisit } from '@openmrs/esm-framework';
-import { BillingConfig } from '../config-schema';
-import { BillingPromptType, MappedBill, PatientInvoice, PaymentStatus } from '../types';
-import useSWR from 'swr';
 import { useMemo } from 'react';
+import useSWR from 'swr';
 import { mapBillProperties } from '../billing.resource';
+import { BillingConfig } from '../config-schema';
+import { BillingPromptType, MappedBill, PatientInvoice } from '../types';
 
 interface BillingPromptResult {
   shouldShowBillingPrompt: boolean;
@@ -140,7 +140,7 @@ export const usePatientBills = (patientUuid: string) => {
   const { patientBillsUrl } = useConfig<BillingConfig>();
   const url = patientBillsUrl.replace('${restBaseUrl}', restBaseUrl);
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<PatientInvoice> } }>(
-    patientUuid ? `${url}&patientUuid=${patientUuid}&includeVoided=true` : url,
+    patientUuid ? `${url}&patientUuid=${patientUuid}&includeVoided=true` : null,
     openmrsFetch,
     {
       errorRetryCount: 2,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR adds a simple check to avoid firing a patient search call when a patient has not been searched. i.e the `patientUUID` is `undefined`.
## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
