### PR TITLE
(feat): include openmrs id on payment history

### DIFF
--- a/packages/esm-billing-app/src/billable-services/payment-history/payment-history-table.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/payment-history/payment-history-table.component.tsx
@@ -1,10 +1,21 @@
-import { DataTableSkeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@carbon/react';
+import {
+  DataTableSkeleton,
+  SkeletonText,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@carbon/react';
 import { EmptyState, ErrorState } from '@openmrs/esm-patient-common-lib';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useBills } from '../../billing.resource';
 import { MappedBill } from '../../types';
 // import { headers } from './payment-history-viewer.component';
+import { useConfig, usePatient } from '@openmrs/esm-framework';
+import { BillingConfig } from '../../config-schema';
 import styles from './payment-history.scss';
 
 export const PaymentHistoryTable = ({
@@ -87,11 +98,40 @@ export const PaymentHistoryTable = ({
               row,
             })}>
             {row.cells.map((cell) => (
-              <TableCell key={cell.id}>{cell.value}</TableCell>
+              <CustomTableCell cell={cell} patientUUID={row.id} />
             ))}
           </TableRow>
         ))}
       </TableBody>
     </Table>
   );
+};
+
+const CustomTableCell = ({
+  cell,
+  patientUUID,
+}: {
+  cell: { id: string; value: string; info: { header: string } };
+  patientUUID: string;
+}) => {
+  const { openMRSIDUUID } = useConfig<BillingConfig>();
+  const { patient, isLoading } = usePatient(patientUUID);
+
+  const openMRSId = patient?.identifier
+    ?.filter((identifier) => identifier)
+    .filter((identifier) => identifier.type.coding.some((coding) => coding.code === openMRSIDUUID))
+    .at(0)?.value;
+
+  if (cell.info.header === 'patientName') {
+    if (isLoading) {
+      return <SkeletonText className={styles.patientNameSkeleton} />;
+    }
+    return (
+      <TableCell key={cell.id}>
+        {openMRSId}:{cell.value}
+      </TableCell>
+    );
+  }
+
+  return <TableCell key={cell.id}>{cell.value}</TableCell>;
 };

--- a/packages/esm-billing-app/src/billable-services/payment-history/payment-history-viewer.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/payment-history/payment-history-viewer.component.tsx
@@ -17,7 +17,7 @@ import { useBills } from '../../billing.resource';
 import { useRenderedRows } from '../../hooks/use-rendered-rows';
 import { usePaymentPoints } from '../../payment-points/payment-points.resource';
 import { useClockInStatus } from '../../payment-points/use-clock-in-status';
-import { PaymentStatus, Timesheet } from '../../types';
+import { MappedBill, PaymentStatus, Timesheet } from '../../types';
 import { AppliedFilterTags } from './applied-filter-tages.component';
 import { Filter } from './filter.component';
 import { PaymentHistoryTable } from './payment-history-table.component';
@@ -91,7 +91,7 @@ export const PaymentHistoryViewer = () => {
 
   return (
     <div className={styles.table}>
-      <PaymentTotals renderedRows={renderedRows} appliedFilters={appliedFilters} />
+      <PaymentTotals renderedRows={renderedRows as unknown as MappedBill[]} appliedFilters={appliedFilters} />
       <DataTable rows={results} headers={headers} isSortable>
         {(tableData) => (
           <TableContainer>
@@ -131,7 +131,7 @@ export const PaymentHistoryViewer = () => {
             <PaymentHistoryTable
               tableData={tableData}
               paidBillsResponse={paidBillsResponse}
-              renderedRows={renderedRows}
+              renderedRows={renderedRows as unknown as MappedBill[]}
             />
             {paginated && !paidBillsResponse.isLoading && !paidBillsResponse.error && (
               <Pagination

--- a/packages/esm-billing-app/src/billable-services/payment-history/payment-history.scss
+++ b/packages/esm-billing-app/src/billable-services/payment-history/payment-history.scss
@@ -84,3 +84,7 @@
   flex-grow: unset;
   margin-right: layout.$spacing-01;
 }
+
+.patientNameSkeleton {
+  margin-top: layout.$spacing-05;
+}

--- a/packages/esm-billing-app/src/config-schema.ts
+++ b/packages/esm-billing-app/src/config-schema.ts
@@ -28,6 +28,7 @@ export interface BillingConfig {
     emergencyPriorityConceptUuid: string;
   };
   paymentMethodsUuidsThatShouldNotShowPrompt: Array<string>;
+  openMRSIDUUID: string;
 }
 
 export const configSchema: ConfigSchema = {
@@ -35,6 +36,11 @@ export const configSchema: ConfigSchema = {
     _type: Type.Boolean,
     _description: 'A flag for PDSL facilities',
     _default: false,
+  },
+  openMRSIDUUID: {
+    _type: Type.String,
+    _description: 'OpenMRS ID uuid',
+    _default: 'dfacd928-0370-4315-99d7-6ec1c9f7ae76',
   },
   shaIdentificationNumberUUID: {
     _type: Type.String,

--- a/packages/esm-billing-app/src/hooks/use-rendered-rows.ts
+++ b/packages/esm-billing-app/src/hooks/use-rendered-rows.ts
@@ -26,7 +26,14 @@ export const useRenderedRows = (bills: MappedBill[], filters: Array<string>, tim
   const serviceTypeFilters = billsServiceTypes.filter((st) => filters.includes(st.uuid)).map((st) => st.uuid);
   const paymentModeFilters = paymentModes?.filter((pm) => filters.includes(pm.name)).map((pm) => pm.name);
 
-  const preFiltered = bills
+  const mappedBills = bills.map((bill) => {
+    return {
+      ...bill,
+      id: bill.patientUuid,
+    };
+  });
+
+  const preFiltered = mappedBills
     .filter((b) => (isOnPaymentPointPage ? b.cashPointUuid === paymentPointUUID : true))
     .filter((bill) => {
       if (!timesheet) {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR adds the patient's openmrs id on the payment history page. The current implementation works but the slight downside is for every patient we have to fetch their openMRS ID from the backend therefore there is a loading state on the patient's name which is not the best user experience, if the bill could come prepopulated with the openMRS ID that would be ideal.

## Screenshots
![image](https://github.com/user-attachments/assets/654f19ce-ce16-4660-839f-2dd32b0938cf)

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
