### PR TITLE
(fix): use service type uuid and handle bulk upload payload construction errors

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billable-service.resource.tsx
+++ b/packages/esm-billing-app/src/billable-services/billable-service.resource.tsx
@@ -1,13 +1,9 @@
 import { OpenmrsResource, openmrsFetch } from '@openmrs/esm-framework';
 import useSWR from 'swr';
-import { ServiceConcept } from '../types';
+import { ServiceConcept, ServiceTypesResponse } from '../types';
 
 type ResponseObject = {
   results: Array<OpenmrsResource>;
-};
-
-type ServiceTypesResponse = {
-  setMembers: { uuid: string; display: string }[];
 };
 
 export const useBillableServices = () => {
@@ -17,7 +13,7 @@ export const useBillableServices = () => {
 };
 
 export function useServiceTypes() {
-  const url = `/ws/rest/v1/concept/d7bd4cc0-90b1-4f22-90f2-ab7fde936727?v=custom:(setMembers:(uuid,display))`;
+  const url = `/ws/rest/v1/concept/d7bd4cc0-90b1-4f22-90f2-ab7fde936727?v=custom:(setMembers:(uuid,display,id))`;
   const { data, error, isLoading } = useSWR<{ data: ServiceTypesResponse }>(url, openmrsFetch, {});
   return { serviceTypes: data?.data.setMembers ?? [], error, isLoading };
 }

--- a/packages/esm-billing-app/src/billable-services/billable-service.resource.tsx
+++ b/packages/esm-billing-app/src/billable-services/billable-service.resource.tsx
@@ -13,7 +13,9 @@ export const useBillableServices = () => {
 };
 
 export function useServiceTypes() {
-  const url = `/ws/rest/v1/concept/d7bd4cc0-90b1-4f22-90f2-ab7fde936727?v=custom:(setMembers:(uuid,display,id))`;
+  // service concept UUID containing all available services e.g lab, pharmacy, surgical etc
+  const serviceConceptUuid = `d7bd4cc0-90b1-4f22-90f2-ab7fde936727`;
+  const url = `/ws/rest/v1/concept/${serviceConceptUuid}?v=custom:(setMembers:(uuid,display,id))`;
   const { data, error, isLoading } = useSWR<{ data: ServiceTypesResponse }>(url, openmrsFetch, {});
   return { serviceTypes: data?.data.setMembers ?? [], error, isLoading };
 }

--- a/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   ComboButton,
   DataTable,
   DataTableSkeleton,
@@ -19,7 +18,7 @@ import {
   TableToolbarContent,
   TableToolbarSearch,
 } from '@carbon/react';
-import { Add, CategoryAdd, Download, Upload, WatsonHealthScalpelSelect } from '@carbon/react/icons';
+import { CategoryAdd, Download, Upload, WatsonHealthScalpelSelect } from '@carbon/react/icons';
 import { ErrorState, launchWorkspace, showModal, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { EmptyState, usePaginationInfo } from '@openmrs/esm-patient-common-lib';
 import React, { useMemo, useState } from 'react';

--- a/packages/esm-billing-app/src/billable-services/billables/form-helper.ts
+++ b/packages/esm-billing-app/src/billable-services/billables/form-helper.ts
@@ -1,5 +1,5 @@
 import * as XLSX from 'xlsx';
-import { ExcelFileRow, PaymentMethod } from '../../types';
+import { ExcelFileRow, PaymentMethod, ServiceType } from '../../types';
 import { ChargeAble } from './charge-summary.resource';
 import { BillableFormSchema, ServicePriceSchema } from './form-schemas';
 
@@ -119,6 +119,7 @@ export const getBulkUploadPayloadFromExcelFile = (
   fileData: Uint8Array,
   currentlyExistingBillableServices: Array<ChargeAble>,
   paymentModes: Array<PaymentMethod>,
+  serviceTypes: Array<ServiceType>,
 ) => {
   const workbook = XLSX.read(fileData, { type: 'array' });
 
@@ -167,7 +168,7 @@ export const getBulkUploadPayloadFromExcelFile = (
       return {
         name: row.name,
         shortName: row.short_name ?? row.name,
-        serviceType: row.service_type_id,
+        serviceType: serviceTypes.find((type) => type.id === row.service_type_id).uuid,
         servicePrices: [
           {
             paymentMode: paymentModes.find((mode) => mode.name === 'Cash').uuid,
@@ -177,7 +178,6 @@ export const getBulkUploadPayloadFromExcelFile = (
         ],
         serviceStatus: row.disable === 'false' ? 'DISABLED' : 'ENABLED',
         concept: row.concept_id,
-        stockItem: '',
       };
     });
 

--- a/packages/esm-billing-app/src/types/index.ts
+++ b/packages/esm-billing-app/src/types/index.ts
@@ -564,3 +564,9 @@ export interface Service {
   concept: string;
   description: string;
 }
+
+export type ServiceType = { uuid: string; display: string; id: number };
+
+export type ServiceTypesResponse = {
+  setMembers: Array<ServiceType>;
+};


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR introduces a fix to solve the issue raised by QA whereby all bulk uploaded charge items were always set to **Stock Items** regardless of the service type ID provided. The fix was to use the service type UUID instead of the ID to pick the service type correctly.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
