### PR TITLE
(feat) KHP3-7230 : Implement configurable payment based access control for clinical services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 **/package-lock.json
+**/package-lock.*
 
 # Runtime data
 pids

--- a/packages/esm-billing-app/src/billable-services/payment-history/payment-history-table.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/payment-history/payment-history-table.component.tsx
@@ -59,6 +59,7 @@ export const PaymentHistoryTable = ({
     return {
       ...row,
       totalAmount: convertToCurrency(row.payments.reduce((acc, payment) => acc + payment.amountTendered, 0)),
+      referenceCodes: row.payments.map(({ attributes }) => attributes.map(({ value }) => value).join(' ')).join(', '),
     };
   });
 
@@ -71,18 +72,18 @@ export const PaymentHistoryTable = ({
     });
     const data = dataForExport.map((row: (typeof transformedRows)[0]) => {
       return {
+        'Receipt Number': row.receiptNumber,
         'Patient ID': row.identifier,
         'Patient Name': row.patientName,
-        'Receipt Number': row.receiptNumber,
-        'Total Amount': row.lineItems.reduce((acc, item) => acc + item.price, 0),
-        'Payment Mode': row.payments.map((payment: (typeof row.payments)[0]) => payment.instanceType.name).join(', '),
-        'Payment Date': dayjs(row.payments[0].dateCreated).format('DD-MM-YYYY'),
-        'Payment Amount': row.payments.reduce((acc, payment) => acc + payment.amountTendered, 0),
+        'Mode of Payment': row.payments
+          .map((payment: (typeof row.payments)[0]) => payment.instanceType.name)
+          .join(', '),
+        'Total Amount Due': row.lineItems.reduce((acc, item) => acc + item.price, 0),
+        'Date of Payment': dayjs(row.payments[0].dateCreated).format('DD-MM-YYYY'),
+        'Total Amount Paid': row.payments.reduce((acc, payment) => acc + payment.amountTendered, 0),
         'Reason/Reference': row.payments
-          .map((payment: (typeof row.payments)[0]) =>
-            payment.attributes.map((attribute: (typeof payment.attributes)[0]) => attribute.attributeType.name),
-          )
-          .join(' '),
+          .map(({ attributes }) => attributes.map(({ value }) => value).join(' '))
+          .join(', '),
       };
     });
 

--- a/packages/esm-billing-app/src/config-schema.ts
+++ b/packages/esm-billing-app/src/config-schema.ts
@@ -28,6 +28,10 @@ export interface BillingConfig {
     emergencyPriorityConceptUuid: string;
   };
   paymentMethodsUuidsThatShouldNotShowPrompt: Array<string>;
+  promptDuration: {
+    enable: boolean;
+    duration: number;
+  };
 }
 
 export const configSchema: ConfigSchema = {
@@ -181,5 +185,14 @@ export const configSchema: ConfigSchema = {
       _type: Type.String,
     },
     _default: ['beac329b-f1dc-4a33-9e7c-d95821a137a6'],
+  },
+  promptDuration: {
+    _type: Type.Object,
+    _description:
+      'The duration in hours for the prompt to be shown, if the duration is less than this, the prompt will be shown',
+    _default: {
+      enable: true,
+      duration: 24,
+    },
   },
 };

--- a/packages/esm-billing-app/src/helpers/functions.ts
+++ b/packages/esm-billing-app/src/helpers/functions.ts
@@ -65,24 +65,19 @@ export const getGender = (gender: string, t) => {
 
 /**
  * Extracts and returns the substring after the first colon (:) in the input string.
- * The input string is expected to be in the format "uuid:string".
+ * If there's no colon or the input is invalid, returns the original string.
+ * The input string is typically in the format "uuid:string".
  *
  * @param {string} input - The input string from which the substring is to be extracted.
- * @returns {string} The substring found after the first colon in the input string.
+ * @returns {string} The substring found after the first colon, or the original string if no colon is present.
  */
 export function extractString(input: string): string {
-  const parts = input
-    .split(' ')
-    .map((s) => s.split(':')[1])
-    .filter((s) => Boolean(s));
-
-  const firstTwoBillableServices = parts.slice(0, 2);
-
-  if (parts.length <= 2) {
-    return firstTwoBillableServices.join(', ');
+  if (!input || typeof input !== 'string') {
+    return '';
   }
 
-  return `${firstTwoBillableServices.join(', ')} & ${parts.length - 2} other services`;
+  const parts = input.split(':');
+  return parts.length > 1 ? parts[1] : input;
 }
 
 // cleans the provider display name

--- a/packages/esm-billing-app/src/prompt-payment/prompt-payment-modal.component.tsx
+++ b/packages/esm-billing-app/src/prompt-payment/prompt-payment-modal.component.tsx
@@ -77,7 +77,7 @@ const PromptPaymentModal: React.FC<PromptPaymentModalProps> = () => {
             <StructuredListBody>
               {lineItems.map((lineItem) => {
                 return (
-                  <StructuredListRow>
+                  <StructuredListRow key={lineItem.uuid}>
                     <StructuredListCell>{extractString(lineItem.billableService || lineItem.item)}</StructuredListCell>
                     <StructuredListCell>{lineItem.quantity}</StructuredListCell>
                     <StructuredListCell>{convertToCurrency(lineItem.price)}</StructuredListCell>

--- a/packages/esm-billing-app/src/prompt-payment/prompt-payment.modal.test.tsx
+++ b/packages/esm-billing-app/src/prompt-payment/prompt-payment.modal.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PromptPaymentModal from './prompt-payment-modal.component';
+import { useBillingPrompt } from './prompt-payment.resource';
+import { navigate, useConfig } from '@openmrs/esm-framework';
+import { PaymentStatus } from '../types';
+import userEvent from '@testing-library/user-event';
+
+const mockNavigate = navigate as jest.MockedFunction<typeof navigate>;
+
+const mockMappedBill = [
+  {
+    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    id: 1,
+    patientUuid: 'patient-uuid-123',
+    patientName: 'John Doe',
+    cashPointUuid: 'cashpoint-uuid-123',
+    cashPointName: 'Main Reception',
+    cashPointLocation: 'Hospital Wing A',
+    cashier: {
+      uuid: 'cashier-uuid-123',
+      display: 'Dr. Jane Smith',
+      links: [
+        {
+          rel: 'self',
+          uri: 'http://example.com/provider/cashier-uuid-123',
+          resourceAlias: 'provider',
+        },
+      ],
+    },
+    receiptNumber: 'REC-2023-001',
+    status: PaymentStatus.PENDING,
+    identifier: 'BILL-001',
+    dateCreated: '2023-08-15T10:30:00.000Z',
+    dateCreatedUnformatted: '2023-08-15',
+    lineItems: [
+      {
+        uuid: 'lineitem-uuid-123',
+        display: 'Consultation Fee',
+        voided: false,
+        voidReason: null,
+        item: 'Consultation',
+        billableService: 'some-uuid:General Consultation',
+        quantity: 1,
+        price: 50.0,
+        priceName: 'Standard Price',
+        priceUuid: 'price-uuid-123',
+        lineItemOrder: 1,
+        resourceVersion: '1.0',
+        paymentStatus: 'PENDING',
+        itemOrServiceConceptUuid: 'concept-uuid-123',
+        serviceTypeUuid: 'service-type-uuid-123',
+        order: {
+          uuid: 'order-uuid-123',
+        },
+      },
+    ],
+    billingService: 'Outpatient Services',
+    payments: [
+      {
+        uuid: 'payment-uuid-123',
+        instanceType: {
+          uuid: 'instance-type-uuid-123',
+          name: 'Cash Payment',
+          description: 'Standard cash payment',
+          retired: false,
+        },
+        attributes: [],
+        amount: 50.0,
+        amountTendered: 50.0,
+        dateCreated: 1692093000000, // Unix timestamp for 2023-08-15T10:30:00.000Z
+        voided: false,
+        resourceVersion: '1.0',
+      },
+    ],
+    totalAmount: 50.0,
+    tenderedAmount: 50.0,
+    display: 'Bill #BILL-001',
+    referenceCodes: 'REF-001',
+    adjustmentReason: undefined,
+  },
+];
+
+const mockUseBillingPrompt = useBillingPrompt as jest.MockedFunction<typeof useBillingPrompt>;
+const mockUseConfig = useConfig as jest.MockedFunction<typeof useConfig>;
+jest.mock('@openmrs/esm-patient-common-lib', () => ({
+  getPatientUuidFromStore: jest.fn(() => 'patient-uuid'),
+}));
+
+jest.mock('@openmrs/esm-framework', () => ({
+  useConfig: jest.fn(),
+  navigate: jest.fn(),
+}));
+
+jest.mock('./prompt-payment.resource', () => ({
+  useBillingPrompt: jest.fn(),
+}));
+
+describe('<PromptPaymentModal />', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('should show the prompt payment modal, when `shouldShowBillingPrompt` is true and `enforceBillPayment` is true', async () => {
+    const user = userEvent.setup();
+    mockUseBillingPrompt.mockReturnValue({
+      shouldShowBillingPrompt: true,
+      isLoading: false,
+      bills: mockMappedBill,
+      currentVisit: null,
+      error: null,
+    });
+    mockUseConfig.mockReturnValue({
+      enforceBillPayment: true,
+    });
+    render(<PromptPaymentModal />);
+    expect(screen.getByText('Patient Billing Alert')).toBeInTheDocument();
+    expect(
+      screen.getByText('The current patient has pending bill. Advice patient to settle bill.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Navigate back')).toBeInTheDocument();
+    // check if the structured list is rendered
+    const structuredListHeaders = ['Item', 'Quantity', 'Unit price', 'Total'];
+    structuredListHeaders.forEach((header) => {
+      expect(screen.getByText(header)).toBeInTheDocument();
+    });
+
+    // clicking cancel button should close the modal
+    const cancelButton = screen.getByText('Cancel');
+    await user.click(cancelButton);
+    expect(mockNavigate).toHaveBeenCalledWith({ to: `\${openmrsSpaBase}/home` });
+    // clicking proceed to care button should close the modal
+    const navigateBackButton = screen.getByText('Navigate back');
+    await user.click(navigateBackButton);
+    expect(mockNavigate).toHaveBeenCalledWith({ to: `\${openmrsSpaBase}/home` });
+  });
+
+  test('should show the prompt payment modal, when `shouldShowBillingPrompt` is true and `enforceBillPayment` is false and not navigate back', async () => {
+    const user = userEvent.setup();
+    mockUseBillingPrompt.mockReturnValue({
+      shouldShowBillingPrompt: true,
+      isLoading: false,
+      bills: mockMappedBill,
+      currentVisit: null,
+      error: null,
+    });
+    mockUseConfig.mockReturnValue({
+      enforceBillPayment: false,
+    });
+
+    render(<PromptPaymentModal />);
+    expect(screen.getByText('Patient Billing Alert')).toBeInTheDocument();
+    expect(
+      screen.getByText('The current patient has pending bill. Advice patient to settle bill.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Proceed to care')).toBeInTheDocument();
+
+    // clicking proceed to care button should close the modal
+    const proceedToCareButton = screen.getByText('Proceed to care');
+    await user.click(proceedToCareButton);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    // clicking cancel button should close the modal
+    const cancelButton = screen.getByText('Cancel');
+    await user.click(cancelButton);
+    expect(mockNavigate).toHaveBeenCalledWith({ to: `\${openmrsSpaBase}/home` });
+  });
+
+  test('should show the loading state when `isLoading` is true', () => {
+    mockUseBillingPrompt.mockReturnValue({
+      shouldShowBillingPrompt: true,
+      isLoading: true,
+      bills: mockMappedBill,
+      currentVisit: null,
+      error: null,
+    });
+    mockUseConfig.mockReturnValue({
+      enforceBillPayment: true,
+    });
+    render(<PromptPaymentModal />);
+    expect(screen.getByText('Billing status')).toBeInTheDocument();
+    expect(screen.getByText('Verifying patient bills')).toBeInTheDocument();
+  });
+
+  test('should not render the modal when `shouldShowBillingPrompt` is false', () => {
+    mockUseBillingPrompt.mockReturnValue({
+      shouldShowBillingPrompt: false,
+      isLoading: false,
+      bills: mockMappedBill,
+      currentVisit: null,
+      error: null,
+    });
+    mockUseConfig.mockReturnValue({
+      enforceBillPayment: true,
+    });
+    render(<PromptPaymentModal />);
+    expect(screen.queryByText('Patient Billing Alert')).not.toBeInTheDocument();
+  });
+});

--- a/packages/esm-billing-app/src/types/index.ts
+++ b/packages/esm-billing-app/src/types/index.ts
@@ -97,6 +97,7 @@ interface AttributeType {
   foreignKey?: string | null;
   regExp?: string | null;
   required: boolean;
+  value?: string;
 }
 
 interface Attribute {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
ticket 👉🏽 https://thepalladiumgroup.atlassian.net/browse/KHP3-7230
Implements configurable payment enforcement periods for clinical services. Services like labs, medications, and imaging require payment before delivery, except for admitted patients.

Key changes:
- Payment enforcement based on configurable duration since last bill
- Payment prompt shows during enforcement period, hides after expiration
- Automatic bypass for admitted patients (in-patient)

Example: With 24-hour enforcement period, system displays payment prompt for 24 hours after bill creation, then hides prompt

## Screenshots
[Kapture 2024-12-16 at 15.13.26.webm](https://github.com/user-attachments/assets/1d7b4577-48ee-4d88-bfa8-90edd4bcddb0)


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
