### PR TITLE
(fix) : remove uuid from service name on transaction history table

### DIFF
--- a/packages/esm-billing-app/src/billable-services/payment-history/payment-history-table.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/payment-history/payment-history-table.component.tsx
@@ -58,6 +58,7 @@ export const PaymentHistoryTable = ({
   const transformedRows = results.map((row) => {
     return {
       ...row,
+      billingService: row.lineItems.map((item) => item.billableService).join(', '),
       totalAmount: convertToCurrency(row.payments.reduce((acc, payment) => acc + payment.amountTendered, 0)),
       referenceCodes: row.payments
         .map(({ attributes }) => attributes.map(({ value }) => value).join(', '))


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR removes uuids from being displayed on payment history table. Will do a follow up PR to centralize the how we extract the service name.  cc @ojwanganto  this is related to the comments on this PR https://github.com/palladiumkenya/kenyaemr-esm-3.x/pull/526#issuecomment-2575342881


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
