### PR TITLE
fix: changed MM to mm in clock in time display

### DIFF
--- a/packages/esm-billing-app/src/billing-dashboard/clock-out-strip.component.tsx
+++ b/packages/esm-billing-app/src/billing-dashboard/clock-out-strip.component.tsx
@@ -32,7 +32,7 @@ export const ClockOutStrip = () => {
       <div className={styles.clockOutInfo}>
         <Alarm />
         <p className={styles.clockInTime}>
-          {t('clockInTime', `Clocked in on ${dayjs(globalActiveSheet.clockIn).format('D MMM YYYY, HH:MM A')}`)}
+          {t('clockInTime', `Clocked in on ${dayjs(globalActiveSheet.clockIn).format('D MMM YYYY, HH:mm A')}`)}
         </p>
         <span className={styles.middot}>&middot;</span>
         <p className={styles.cashPointName}>{globalActiveSheet.cashPoint.name}</p>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This a minimal fix turns out `${dayjs(globalActiveSheet.clockIn).format('D MMM YYYY, HH:MM A')}` gives you the top of the hour while `${dayjs(globalActiveSheet.clockIn).format('D MMM YYYY, HH:mm A')}` gives you the exact minute. So what would happen is you'd see **9:01 AM** instead of **9:22 AM**.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
