### PR TITLE
fix: broken bulk upload (Draft)

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billable-service.resource.tsx
+++ b/packages/esm-billing-app/src/billable-services/billable-service.resource.tsx
@@ -26,8 +26,9 @@ export const usePaymentModes = () => {
   return { paymentModes: data?.data.results ?? [], error, isLoading };
 };
 
-export const createBillableService = (payload: any, uuid?: string) => {
+export const createBillableService = (payload: any) => {
   const url = `/ws/rest/v1/cashier/api/billable-service`;
+
   return openmrsFetch(url, {
     method: 'POST',
     body: payload,
@@ -36,6 +37,7 @@ export const createBillableService = (payload: any, uuid?: string) => {
     },
   });
 };
+
 export const deleteBillableService = (payload: any) => {
   const url = `/ws/rest/v1/cashier/api/deletebillable-service`;
   return openmrsFetch(url, {

--- a/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
@@ -18,7 +18,7 @@ import {
   TableToolbarContent,
   TableToolbarSearch,
 } from '@carbon/react';
-import { CategoryAdd, Download, Upload, WatsonHealthScalpelSelect } from '@carbon/react/icons';
+import { CategoryAdd, DocumentDownload, Download, Upload, WatsonHealthScalpelSelect } from '@carbon/react/icons';
 import { ErrorState, launchWorkspace, showModal, useLayoutType, usePagination } from '@openmrs/esm-framework';
 import { EmptyState, usePaginationInfo } from '@openmrs/esm-patient-common-lib';
 import React, { useMemo, useState } from 'react';
@@ -156,8 +156,8 @@ const ChargeSummaryTable: React.FC = () => {
                   <MenuItem onClick={openBulkUploadModal} label={t('bulkUpload', 'Bulk Upload')} renderIcon={Upload} />
                   <MenuItem
                     onClick={downloadExcelTemplateFile}
-                    label={t('downloadTemplate', 'Download upload template')}
-                    renderIcon={Download}
+                    label={t('downloadUploadTemplate', 'Download upload template')}
+                    renderIcon={DocumentDownload}
                   />
                   <MenuItem
                     onClick={handleDownloadChargeItems}

--- a/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
@@ -24,6 +24,7 @@ import { EmptyState, usePaginationInfo } from '@openmrs/esm-patient-common-lib';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { convertToCurrency } from '../../helpers';
+import { downloadChargeItems } from '../utils';
 import styles from './charge-summary-table.scss';
 import { useChargeSummaries } from './charge-summary.resource';
 import { downloadExcelTemplateFile, searchTableData } from './form-helper';
@@ -103,6 +104,10 @@ const ChargeSummaryTable: React.FC = () => {
     });
   };
 
+  const handleDownloadChargeItems = () => {
+    downloadChargeItems(chargeSummaryItems);
+  };
+
   if (isLoading) {
     return <DataTableSkeleton headers={headers} aria-label="sample table" showHeader={false} showToolbar={false} />;
   }
@@ -151,7 +156,12 @@ const ChargeSummaryTable: React.FC = () => {
                   <MenuItem onClick={openBulkUploadModal} label={t('bulkUpload', 'Bulk Upload')} renderIcon={Upload} />
                   <MenuItem
                     onClick={downloadExcelTemplateFile}
-                    label={t('downloadTemplate', 'Download template')}
+                    label={t('downloadTemplate', 'Download upload template')}
+                    renderIcon={Download}
+                  />
+                  <MenuItem
+                    onClick={handleDownloadChargeItems}
+                    label={t('downloadChargeItems', 'Download charge items')}
                     renderIcon={Download}
                   />
                 </ComboButton>

--- a/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/charge-summary-table.component.tsx
@@ -23,6 +23,7 @@ import { ErrorState, launchWorkspace, showModal, useLayoutType, usePagination } 
 import { EmptyState, usePaginationInfo } from '@openmrs/esm-patient-common-lib';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { usePaymentModes } from '../../billing.resource';
 import { convertToCurrency } from '../../helpers';
 import { downloadChargeItems } from '../utils';
 import styles from './charge-summary-table.scss';
@@ -36,6 +37,7 @@ const ChargeSummaryTable: React.FC = () => {
   const layout = useLayoutType();
   const size = layout === 'tablet' ? 'lg' : 'md';
   const { isLoading, isValidating, error, mutate, chargeSummaryItems } = useChargeSummaries();
+  const { paymentModes } = usePaymentModes();
   const [pageSize, setPageSize] = useState(defaultPageSize);
   const [searchString, setSearchString] = useState('');
 
@@ -105,7 +107,7 @@ const ChargeSummaryTable: React.FC = () => {
   };
 
   const handleDownloadChargeItems = () => {
-    downloadChargeItems(chargeSummaryItems);
+    downloadChargeItems(chargeSummaryItems, paymentModes);
   };
 
   if (isLoading) {
@@ -155,7 +157,7 @@ const ChargeSummaryTable: React.FC = () => {
                   />
                   <MenuItem onClick={openBulkUploadModal} label={t('bulkUpload', 'Bulk Upload')} renderIcon={Upload} />
                   <MenuItem
-                    onClick={downloadExcelTemplateFile}
+                    onClick={() => downloadExcelTemplateFile(paymentModes)}
                     label={t('downloadUploadTemplate', 'Download upload template')}
                     renderIcon={DocumentDownload}
                   />

--- a/packages/esm-billing-app/src/billable-services/billables/charge-summary.resource.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/charge-summary.resource.tsx
@@ -1,5 +1,6 @@
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import useSWR from 'swr';
+import { PaymentMode } from '../../types';
 
 export type ChargeAble = {
   uuid: string;
@@ -16,6 +17,7 @@ export type ChargeAble = {
     uuid: string;
     name: string;
     price: number;
+    paymentMode: PaymentMode;
   }>;
   concept: {
     uuid: string;

--- a/packages/esm-billing-app/src/billable-services/billables/charge-summary.resource.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/charge-summary.resource.tsx
@@ -10,6 +10,7 @@ export type ChargeAble = {
   serviceType: {
     uuid: string;
     display: string;
+    id: string;
   };
   servicePrices: Array<{
     uuid: string;
@@ -19,6 +20,7 @@ export type ChargeAble = {
   concept: {
     uuid: string;
     display: string;
+    id: string;
   };
 };
 
@@ -27,7 +29,7 @@ type ChargeAblesResponse = {
 };
 
 export const useChargeSummaries = () => {
-  const url = `${restBaseUrl}/cashier/billableService?v=custom:(uuid,name,shortName,serviceStatus,serviceType:(uuid,display),servicePrices:(uuid,name,paymentMode,price),concept:(uuid,display))`;
+  const url = `${restBaseUrl}/cashier/billableService?v=custom:(uuid,name,shortName,serviceStatus,serviceType:(uuid,id,display),servicePrices:(uuid,name,paymentMode,price),concept:(uuid,id,display))`;
   const { data, isLoading, isValidating, error, mutate } = useSWR<{ data: ChargeAblesResponse }>(url, openmrsFetch, {
     errorRetryCount: 0,
   });

--- a/packages/esm-billing-app/src/billable-services/billables/form-helper.ts
+++ b/packages/esm-billing-app/src/billable-services/billables/form-helper.ts
@@ -185,7 +185,7 @@ export const getBulkUploadPayloadFromExcelFile = (
 };
 
 export function createExcelTemplateFile(): Uint8Array {
-  const headers = ['concept_id', 'name', 'short_name', 'price', 'disable', 'service_type_id'];
+  const headers = ['name', 'short_name', 'service_status', 'service_type_id', 'concept_id', 'Cash'];
 
   const worksheet = XLSX.utils.aoa_to_sheet([headers]);
   const workbook = XLSX.utils.book_new();
@@ -193,12 +193,12 @@ export function createExcelTemplateFile(): Uint8Array {
 
   // Set column widths for better readability
   const colWidths = [
-    { wch: 15 }, // concept_id
     { wch: 30 }, // name
     { wch: 20 }, // short_name
-    { wch: 10 }, // price
-    { wch: 10 }, // disable
+    { wch: 10 }, // service_status
     { wch: 20 }, // service_type_id
+    { wch: 15 }, // concept_id
+    { wch: 10 }, // Cash
   ];
   worksheet['!cols'] = colWidths;
 

--- a/packages/esm-billing-app/src/billable-services/billables/services/service-form.workspace.tsx
+++ b/packages/esm-billing-app/src/billable-services/billables/services/service-form.workspace.tsx
@@ -1,31 +1,31 @@
-import React, { useState, useMemo, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import {
-  ButtonSet,
   Button,
+  ButtonSet,
+  ComboBox,
+  InlineLoading,
+  InlineNotification,
   Stack,
   TextInput,
-  ComboBox,
   Toggle,
-  InlineNotification,
-  InlineLoading,
 } from '@carbon/react';
 import { Add } from '@carbon/react/icons';
-import { Controller, useFieldArray, useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Controller, FormProvider, useFieldArray, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
 
-import { useLayoutType, useDebounce, ResponsiveWrapper, showSnackbar, restBaseUrl } from '@openmrs/esm-framework';
+import { ResponsiveWrapper, restBaseUrl, showSnackbar, useDebounce, useLayoutType } from '@openmrs/esm-framework';
 import { DefaultPatientWorkspaceProps } from '@openmrs/esm-patient-common-lib';
 
 import { createBillableService, useConceptsSearch, useServiceTypes } from '../../billable-service.resource';
-import PriceField from './price.component';
 import { billableFormSchema, BillableFormSchema } from '../form-schemas';
+import PriceField from './price.component';
 
 import classNames from 'classnames';
-import styles from './service-form.scss';
+import { handleMutate } from '../../utils';
 import { formatBillableServicePayloadForSubmission, mapInputToPayloadSchema } from '../form-helper';
 import ConceptSearch from './concept-search.component';
-import { handleMutate } from '../../utils';
+import styles from './service-form.scss';
 
 interface AddServiceFormProps extends DefaultPatientWorkspaceProps {
   initialValues?: BillableFormSchema;

--- a/packages/esm-billing-app/src/billable-services/utils.ts
+++ b/packages/esm-billing-app/src/billable-services/utils.ts
@@ -1,6 +1,6 @@
 import { mutate } from 'swr';
 import * as XLSX from 'xlsx';
-import { ExcelFileRow } from '../types';
+import { PaymentMode } from '../types';
 import { ChargeAble } from './billables/charge-summary.resource';
 import { BillableServicePayload } from './billables/form-helper';
 
@@ -37,12 +37,12 @@ export const createAndDownloadFailedUploadsExcelFile = (data: BillableServicePay
   document.body.removeChild(link);
 };
 
-export const downloadChargeItems = (data: ChargeAble[]) => {
+export const downloadChargeItems = (data: ChargeAble[], paymentModes: PaymentMode[]) => {
   const workSheetData = data.map((dataItem) => {
-    const chargeAbleItemPrices = dataItem.servicePrices.reduce((acc, curr) => {
+    const chargeAbleItemPrices = paymentModes.reduce((acc, curr) => {
       return {
         ...acc,
-        [curr.name]: curr.price,
+        [curr.name]: dataItem.servicePrices.find((price) => price.paymentMode.uuid === curr.uuid)?.price ?? null,
       };
     }, {});
 
@@ -68,29 +68,6 @@ export const downloadChargeItems = (data: ChargeAble[]) => {
   const link = document.createElement('a');
   link.href = URL.createObjectURL(blob);
   link.download = 'charge-items.xlsx';
-
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-};
-
-export const createAndDownloadFilteredRowsFile = (data: ExcelFileRow[]) => {
-  const worksheetData = data.map((item) => ({
-    ...item,
-  }));
-
-  const worksheet = XLSX.utils.json_to_sheet(worksheetData);
-
-  const workbook = XLSX.utils.book_new();
-  XLSX.utils.book_append_sheet(workbook, worksheet, 'Sheet1');
-
-  const excelBuffer = XLSX.write(workbook, { bookType: 'xlsx', type: 'array' });
-
-  const blob = new Blob([excelBuffer], { type: 'application/octet-stream' });
-
-  const link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = 'filtered-out-billable-services.xlsx';
 
   document.body.appendChild(link);
   link.click();

--- a/packages/esm-billing-app/src/billable-services/utils.ts
+++ b/packages/esm-billing-app/src/billable-services/utils.ts
@@ -1,6 +1,7 @@
 import { mutate } from 'swr';
 import * as XLSX from 'xlsx';
 import { ExcelFileRow } from '../types';
+import { ChargeAble } from './billables/charge-summary.resource';
 import { BillableServicePayload } from './billables/form-helper';
 
 export const handleMutate = (url: string) => {
@@ -30,6 +31,43 @@ export const createAndDownloadFailedUploadsExcelFile = (data: BillableServicePay
   const link = document.createElement('a');
   link.href = URL.createObjectURL(blob);
   link.download = 'failed-billable-services.xlsx';
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
+export const downloadChargeItems = (data: ChargeAble[]) => {
+  const workSheetData = data.map((dataItem) => {
+    const chargeAbleItemPrices = dataItem.servicePrices.reduce((acc, curr) => {
+      return {
+        ...acc,
+        [curr.name]: curr.price,
+      };
+    }, {});
+
+    return {
+      name: dataItem.name,
+      short_name: dataItem.shortName,
+      service_status: dataItem.serviceStatus,
+      service_type_id: dataItem.serviceType?.id ?? null,
+      concept_id: dataItem.concept?.id ?? null,
+      ...chargeAbleItemPrices,
+    };
+  });
+
+  const worksheet = XLSX.utils.json_to_sheet(workSheetData);
+
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Sheet1');
+
+  const excelBuffer = XLSX.write(workbook, { bookType: 'xlsx', type: 'array' });
+
+  const blob = new Blob([excelBuffer], { type: 'application/octet-stream' });
+
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'charge-items.xlsx';
 
   document.body.appendChild(link);
   link.click();

--- a/packages/esm-billing-app/src/types/index.ts
+++ b/packages/esm-billing-app/src/types/index.ts
@@ -471,12 +471,12 @@ export interface Link {
 }
 
 export type ExcelFileRow = {
-  concept_id: number;
   name: string;
-  price: number;
-  disable: 'false' | 'true';
-  service_type_id: number;
   short_name: string;
+  service_status: 'false' | 'true';
+  service_type_id: number;
+  concept_id: number;
+  [key: string]: string | number;
 };
 
 export type PaymentMode = {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR adds/enhances a way for users to 
- download charge items ✅
- download blank bulk upload template ✅
- bulk upload new charge items

However, I am currently stuck on a feature whereby given a `concept_id` I cannot figure out how to get its `uuid` to make the post request with. Normally when you fill out a form to create a new charge item you search for and select a concept, the selected concept's uuid is then posted to the backend. Still, you wouldn't expect users to fill in `UUIDs` on an Excel sheet so I went with the ID approach as they are way shorter and much more flexible. unfortunately, I can't find a way to translate the ID to a uuid. If I try sending the ID to the backend the `ChargeItem's` concept is just nullified regardless of updating or creating..

So in so many words do not merge yet. Check [this](https://github.com/amosmachora/kenyaemr-esm-3.x/blob/2306c480df92e579e0df17bfc0835475e0f62168/packages/esm-billing-app/src/billable-services/billables/form-helper.ts#L187).
## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
