### PR TITLE
(Fix) renamed labels in claims form

### DIFF
--- a/packages/esm-billing-app/src/claims/dashboard/form/claims-form.component.tsx
+++ b/packages/esm-billing-app/src/claims/dashboard/form/claims-form.component.tsx
@@ -200,7 +200,6 @@ const ClaimsForm: React.FC<ClaimsFormProps> = ({ bill, selectedLineItems }) => {
       </Layer>
     );
   }
-
   return (
     <FormProvider {...form}>
       <Form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
@@ -333,7 +332,7 @@ const ClaimsForm: React.FC<ClaimsFormProps> = ({ bill, selectedLineItems }) => {
                     invalid={form.formState.errors[field.name]?.message}
                     invalidText={form.formState.errors[field.name]?.message}
                     id="diagnoses"
-                    titleText={t('diagnosis', 'Diagnosis')}
+                    titleText={t('finalDiagnosis', 'Final Diagnosis')}
                     selectedItems={field.value}
                     label="Choose option"
                     items={diagnoses.map((r) => r.id)}

--- a/packages/esm-billing-app/src/claims/metrics/metrics.component.tsx
+++ b/packages/esm-billing-app/src/claims/metrics/metrics.component.tsx
@@ -35,9 +35,9 @@ const MainMetrics: React.FC<MainMetricsProps> = ({ selectedLineItems, bill }) =>
           headerLabel={t('claimsItems', 'Claims Items')}
         />
         <MetricsCard
-          label={t('date', 'Date of Claimed')}
+          label={t('date', 'Date of Claim')}
           value={formatDate(bill.dateCreated)}
-          headerLabel={t('date', 'Date of Claimed')}
+          headerLabel={t('date', 'Date of Claim')}
         />
       </div>
     </>

--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -76,7 +76,7 @@
   "createClaimError": "Create Claim error",
   "created": "Created",
   "creating": "Creating",
-  "date": "Date of Claimed",
+  "date": "Date of Claim",
   "dateCreated": "Date Created",
   "delete": "Delete",
   "deleteBill": "Delete Bill",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Renamed two labels in the form
Date of Claimed->Date of Claim
Diagnosis-> Final Diagnosis 
 
## Screenshots

*None.*
![Screenshot from 2025-01-15 16-36-45](https://github.com/user-attachments/assets/35a62bd7-cba1-4582-953f-0b9fc51d56cd)
![Screenshot from 2025-01-15 16-39-00](https://github.com/user-attachments/assets/c024807e-728d-4d71-94e0-dc7a5ef65cb0)



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
