### PR TITLE
fix: removed claim modal step and verified SHA number billing check

### DIFF
--- a/packages/esm-billing-app/src/billing-form/hie.resource.tsx
+++ b/packages/esm-billing-app/src/billing-form/hie.resource.tsx
@@ -11,7 +11,7 @@ type HIEEligibilityResponse = {
   eligibility_response: EligibilityResponse;
 };
 
-export const useHIEEligibility = (patientUuid: string) => {
+export const useHIEEligibility = (patientUuid: string, shaIdentificationNumber?: fhir.Identifier[]) => {
   const { patient } = usePatient(patientUuid);
   const { nationalIdUUID } = useConfig<BillingConfig>();
 
@@ -20,7 +20,9 @@ export const useHIEEligibility = (patientUuid: string) => {
     .filter((identifier) => identifier.type.coding.some((coding) => coding.code === nationalIdUUID))
     ?.at(0)?.value;
 
-  const url = `${restBaseUrl}/insuranceclaims/CoverageEligibilityRequest?patientUuid=${patientUuid}&nationalId=${nationalId}`;
+  const url = shaIdentificationNumber
+    ? `${restBaseUrl}/insuranceclaims/CoverageEligibilityRequest?patientUuid=${patientUuid}&nationalId=${nationalId}`
+    : undefined; // this is to avoid making the request if the patient does not have a SHA Id.
   const { data, error, isLoading, mutate } = useSWR<{ data: Array<HIEEligibilityResponse> }>(url, openmrsFetch, {
     errorRetryCount: 0,
   });

--- a/packages/esm-billing-app/src/billing-form/hie.resource.tsx
+++ b/packages/esm-billing-app/src/billing-form/hie.resource.tsx
@@ -2,7 +2,41 @@ import { openmrsFetch, restBaseUrl, useConfig, usePatient } from '@openmrs/esm-f
 import useSWR from 'swr';
 import { BillingConfig } from '../config-schema';
 
-type EligibilityResponse = { message: { eligible: 0 | 1; possible_solution: string; reason: string } };
+export interface EligibilityResponse {
+  requestIdType: number;
+  requestIdNumber: string;
+  memberCrNumber: string;
+  fullName: string;
+  memberType: string;
+  coverageStartDate: Date;
+  coverageEndDate: Date;
+  status: number;
+  message: string;
+  reason: string;
+  possibleSolution: null;
+  coverageType: string;
+  primaryContributor: null;
+  employerDetails: EmployerDetails;
+  dependants: any[];
+  active: boolean;
+}
+
+export interface EmployerDetails {
+  employerName: string;
+  jobGroup: string;
+  scheme: Scheme;
+}
+
+export interface Scheme {
+  schemeCode: string;
+  schemeName: string;
+  schemeCategoryCode: string;
+  schemeCategoryName: string;
+  memberPolicyStartDate: string;
+  memberPolicyEndDate: string;
+  joinDate: string;
+  leaveDate: string;
+}
 
 type HIEEligibilityResponse = {
   insurer: string;

--- a/packages/esm-billing-app/src/billing-form/hie.resource.tsx
+++ b/packages/esm-billing-app/src/billing-form/hie.resource.tsx
@@ -45,7 +45,7 @@ type HIEEligibilityResponse = {
   eligibility_response: EligibilityResponse;
 };
 
-export const useHIEEligibility = (patientUuid: string, shaIdentificationNumber?: fhir.Identifier[]) => {
+export const useSHAEligibility = (patientUuid: string, shaIdentificationNumber?: fhir.Identifier[]) => {
   const { patient } = usePatient(patientUuid);
   const { nationalIdUUID } = useConfig<BillingConfig>();
 
@@ -62,13 +62,9 @@ export const useHIEEligibility = (patientUuid: string, shaIdentificationNumber?:
   });
 
   return {
-    data:
-      data?.data.map((d) => {
-        return {
-          ...d,
-          eligibility_response: JSON.parse(d.eligibility_response as unknown as string) as EligibilityResponse,
-        };
-      }) ?? [],
+    data: data
+      ? { ...(JSON.parse(data?.data.at(0)?.eligibility_response as unknown as string) as EligibilityResponse) }
+      : undefined,
     isLoading,
     error,
     mutate,

--- a/packages/esm-billing-app/src/billing-form/hie.resource.tsx
+++ b/packages/esm-billing-app/src/billing-form/hie.resource.tsx
@@ -54,9 +54,10 @@ export const useSHAEligibility = (patientUuid: string, shaIdentificationNumber?:
     .filter((identifier) => identifier.type.coding.some((coding) => coding.code === nationalIdUUID))
     ?.at(0)?.value;
 
-  const url = shaIdentificationNumber
-    ? `${restBaseUrl}/insuranceclaims/CoverageEligibilityRequest?patientUuid=${patientUuid}&nationalId=${nationalId}`
-    : undefined; // this is to avoid making the request if the patient does not have a SHA Id.
+  const url =
+    shaIdentificationNumber?.length > 0
+      ? `${restBaseUrl}/insuranceclaims/CoverageEligibilityRequest?patientUuid=${patientUuid}&nationalId=${nationalId}`
+      : undefined; // this is to avoid making the request if the patient does not have a SHA Id.
   const { data, error, isLoading, mutate } = useSWR<{ data: Array<HIEEligibilityResponse> }>(url, openmrsFetch, {
     errorRetryCount: 0,
   });

--- a/packages/esm-billing-app/src/billing-form/hie.resource.tsx
+++ b/packages/esm-billing-app/src/billing-form/hie.resource.tsx
@@ -17,7 +17,7 @@ export interface EligibilityResponse {
   coverageType: string;
   primaryContributor: null;
   employerDetails: EmployerDetails;
-  dependants: any[];
+  dependants: Array<unknown>;
   active: boolean;
 }
 

--- a/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
+++ b/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
@@ -20,33 +20,16 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
   const { patient, isLoading } = usePatient(patientUuid);
   const { watch } = useFormContext();
   const isSHA = watch('insuranceScheme')?.includes('SHA');
-  const { data, isLoading: isLoadingHIEEligibility, error } = useHIEEligibility(patientUuid);
-
   const shaIdentificationNumber = patient?.identifier
     ?.filter((identifier) => identifier)
     .filter((identifier) => identifier.type.coding.some((coding) => coding.code === shaIdentificationNumberUUID));
+
+  const { data, isLoading: isLoadingHIEEligibility, error } = useHIEEligibility(patientUuid, shaIdentificationNumber);
 
   const isHIEEligible = true;
 
   if (!isSHA) {
     return null;
-  }
-
-  if (isLoadingHIEEligibility || isLoading) {
-    return <InlineLoading status="active" description={t('loading', 'Loading ...')} />;
-  }
-
-  if (error) {
-    return (
-      <InlineNotification
-        aria-label="closes notification"
-        kind="error"
-        lowContrast={true}
-        statusIconDescription="notification"
-        title={t('error', 'Error')}
-        subtitle={t('errorRetrievingHIESubscription', 'Error retrieving HIE subscription')}
-      />
-    );
   }
 
   if (shaIdentificationNumber?.length === 0) {
@@ -64,6 +47,23 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
         onActionButtonClick={() => {
           navigate({ to: `\${openmrsSpaBase}/patient/${patientUuid}/edit` });
         }}
+      />
+    );
+  }
+
+  if (isLoadingHIEEligibility || isLoading) {
+    return <InlineLoading status="active" description={t('loading', 'Loading ...')} />;
+  }
+
+  if (error) {
+    return (
+      <InlineNotification
+        aria-label="closes notification"
+        kind="error"
+        lowContrast={true}
+        statusIconDescription="notification"
+        title={t('error', 'Error')}
+        subtitle={t('errorRetrievingHIESubscription', 'Error retrieving HIE subscription')}
       />
     );
   }

--- a/packages/esm-billing-app/src/invoice/invoice.resource.ts
+++ b/packages/esm-billing-app/src/invoice/invoice.resource.ts
@@ -1,0 +1,81 @@
+import { Concept, openmrsFetch, restBaseUrl, toDateObjectStrict, toOmrsIsoString, Visit } from '@openmrs/esm-framework';
+import useSWR from 'swr';
+
+export interface VisitQueueEntry {
+  queueEntry: VisitQueueEntry;
+  uuid: string;
+  visit: Visit;
+  queue: Queue;
+}
+
+export interface Queue {
+  uuid: string;
+  display: string;
+  name: string;
+  description: string;
+  location: Location;
+  service: string;
+  allowedPriorities: Array<Concept>;
+  allowedStatuses: Array<Concept>;
+}
+
+export interface MappedVisitQueueEntry {
+  visitUuid: string;
+  queue: Queue;
+  queueEntryUuid: string;
+}
+
+export function useVisitQueueEntry(
+  patientUuid: string,
+  visitUuid: string,
+): {
+  queueEntry: MappedVisitQueueEntry | null;
+  isLoading: boolean;
+  error: Error;
+  isValidating?: boolean;
+  mutate: () => void;
+} {
+  const apiUrl = `${restBaseUrl}/visit-queue-entry?v=full&patient=${patientUuid}`;
+  const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: { results: Array<VisitQueueEntry> } }, Error>(
+    apiUrl,
+    openmrsFetch,
+  );
+
+  const mappedVisitQueueEntry =
+    data?.data?.results
+      ?.map(
+        (visitQueueEntry: VisitQueueEntry): MappedVisitQueueEntry => ({
+          queue: visitQueueEntry.queueEntry.queue,
+          queueEntryUuid: visitQueueEntry.queueEntry.uuid,
+          visitUuid: visitQueueEntry.visit?.uuid,
+        }),
+      )
+      .filter((visitQueueEntry) => visitUuid !== undefined && visitUuid === visitQueueEntry.visitUuid)
+      .shift() ?? null;
+
+  return {
+    queueEntry: mappedVisitQueueEntry,
+    isLoading,
+    error: error,
+    isValidating,
+    mutate,
+  };
+}
+
+export function removeQueuedPatient(
+  queueUuid: string,
+  queueEntryUuid: string,
+  abortController: AbortController,
+  endedAt?: Date,
+) {
+  return openmrsFetch(`${restBaseUrl}/queue/${queueUuid}/entry/${queueEntryUuid}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: {
+      endedAt: toDateObjectStrict(toOmrsIsoString(endedAt) ?? toOmrsIsoString(new Date())),
+    },
+    signal: abortController.signal,
+  });
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR
- Disables the claims button if the bill is not paid
- Removes the end visit confirmation modal
- Refactors the check on SHA before a user is billed on the visit form

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other
Currently, the API for getting SHA returns a 202 successful response but the data is inaccurate. I do not think that should stand in the way of this PR getting merged because when the backend guys fix that everything will be smooth sailing.