### PR TITLE
refactor: use sha status to check if user is registered

### DIFF
--- a/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
+++ b/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
@@ -27,7 +27,6 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
   const { data, isLoading: isLoadingHIEEligibility, error } = useSHAEligibility(patientUuid, shaIdentificationNumber);
 
   const isRegisteredOnSHA = data?.status === 1;
-  const isNotRegisteredOnSHA = data?.status === 0;
 
   const isActive = isRegisteredOnSHA
     ? isWithinInterval(new Date(), {
@@ -76,7 +75,7 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
     );
   }
 
-  if (isNotRegisteredOnSHA) {
+  if (!isRegisteredOnSHA) {
     return (
       <InlineNotification
         title={t('HIEVerificationFailure', 'HIE verification failure')}

--- a/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
+++ b/packages/esm-billing-app/src/billing-form/social-health-authority/sha-number-validity.component.tsx
@@ -26,7 +26,7 @@ const SHANumberValidity: React.FC<SHANumberValidityProps> = ({ paymentMethod, pa
 
   const { data, isLoading: isLoadingHIEEligibility, error } = useSHAEligibility(patientUuid, shaIdentificationNumber);
 
-  const isRegisteredOnSHA = Boolean(data?.coverageEndDate) && Boolean(data?.coverageStartDate);
+  const isRegisteredOnSHA = data?.status === 1;
   const isNotRegisteredOnSHA = data?.status === 0;
 
   const isActive = isRegisteredOnSHA


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
A really simple fix to fix a sneaky bug because the API returns a status code of 1 if users are registered, whether or not they are active. so to separate `isActive` and `isRegistered` we check for status for the latter and whether or not the `coverageStartDate` and `coverageEndDate` are in range for `isActive`.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
