### PR TITLE
(enhc) : Add link to reporting UI for o3

### DIFF
--- a/packages/esm-patient-flags-app/src/navbar/nav-utils.tsx
+++ b/packages/esm-patient-flags-app/src/navbar/nav-utils.tsx
@@ -17,6 +17,7 @@ import {
 } from '@carbon/react/icons';
 import { useConfig } from '@openmrs/esm-framework';
 import { ConfigObject } from '../config-schema';
+import { useTranslation } from 'react-i18next';
 const openmrsSpaBase = window['getOpenmrsSpaBase']();
 
 const handleClearCache = async () => {
@@ -29,6 +30,7 @@ const handleClearCache = async () => {
 };
 
 export const useModuleLinks = () => {
+  const { t } = useTranslation();
   const config = useConfig<ConfigObject>();
   return [
     {
@@ -111,6 +113,11 @@ export const useModuleLinks = () => {
       url: `${openmrsSpaBase}cross-border`,
       icon: <WatsonHealthCrossReference size={24} />,
       privilege: 'o3: View Cross Border Dashboard',
+    },
+    {
+      label: t('reports', 'Reports'),
+      url: `${openmrsSpaBase}reports`,
+      icon: <Report size={24} />,
     },
   ];
 };


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

This PR adds a link on `KenyaEMR modules` navbar section to view o3 reports


## Screenshots
<img width="960" alt="Screenshot 2025-02-25 at 11 27 45" src="https://github.com/user-attachments/assets/16166f64-12af-455d-a4d8-27eb19d941f9" />

## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
