### PR TITLE
use none percentage threshold for hei indicators

### DIFF
--- a/packages/esm-facility-dashboard-app/src/surveillance/summary-cards/surveillance-summary-cards.component.tsx
+++ b/packages/esm-facility-dashboard-app/src/surveillance/summary-cards/surveillance-summary-cards.component.tsx
@@ -75,21 +75,21 @@ const SurveillanceSummaryCards = () => {
         header={t('dnapcrPending', 'DNA-PCR Pending')}
         title={t('HEIWithoutDNAPCR', 'HEI (6-8 WEEKS) without DNA PCR Results')}
         value={`${surveillanceSummary?.getHeiSixToEightWeeksWithoutPCRResults}`}
-        mode={getIndication(
-          surveillanceSummary?.getHeiSixToEightWeeksWithoutPCRResults,
-          surveillanceSummary?.getHeiSixToEightWeeksOld,
-          surveillanceSummary?.heiClinicalActionThreshold,
-        )}
+        mode={
+          surveillanceSummary?.getHeiSixToEightWeeksWithoutPCRResults >= surveillanceSummary?.heiClinicalActionThreshold
+            ? 'increasing'
+            : 'decreasing'
+        }
       />
       <SummaryCard
         header={t('heiIncomplete', 'HEI Incomplete')}
         title={t('HEIWithoutFinalDocumentedOutcome', 'HEI (24 months) without final documented outcomes')}
         value={`${surveillanceSummary?.getHei24MonthsWithoutDocumentedOutcome}`}
-        mode={getIndication(
-          surveillanceSummary?.getHei24MonthsWithoutDocumentedOutcome,
-          surveillanceSummary?.getHei24MonthsOld,
-          surveillanceSummary?.heiClinicalActionThreshold,
-        )}
+        mode={
+          surveillanceSummary?.getHei24MonthsWithoutDocumentedOutcome >= surveillanceSummary?.heiClinicalActionThreshold
+            ? 'increasing'
+            : 'decreasing'
+        }
       />
     </Layer>
   );


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
<img width="776" alt="Screenshot 2025-03-10 at 15 32 20" src="https://github.com/user-attachments/assets/c81a72e0-a836-4ff2-a68d-0013f9f0ad34" />

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
