### PR TITLE
(fix) KHP3-7575 : Default modal name to lab order

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billiable-item/order-actions/components/generic-button.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/order-actions/components/generic-button.component.tsx
@@ -15,7 +15,7 @@ export interface GenericOrderButtonProps {
 
 export const GenericOrderButton: React.FC<GenericOrderButtonProps> = ({
   order,
-  modalName,
+  modalName = 'pickup-lab-request-modal',
   additionalProps,
   actionText,
 }) => {

--- a/packages/esm-billing-app/src/billable-services/billiable-item/order-actions/components/medication-order-button.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/order-actions/components/medication-order-button.component.tsx
@@ -49,7 +49,7 @@ export const MedicationOrderButton: React.FC<MedicationOrderButtonProps> = ({
     if (dispenseFormProps) {
       launchWorkspace('dispense-workspace', dispenseFormProps);
     }
-  }, [modalName, shouldShowBillModal, handleModalClose, medicationRequestBundle, dispenseFormProps]);
+  }, [modalName, shouldShowBillModal, handleModalClose, medicationRequestBundle, dispenseFormProps, patientUuid]);
 
   if (!closeable) {
     return null;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Fix an error when trying to pick lab orders

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
