### PR TITLE
(feat) KHP3-7838 : Implement mortuary module priviliges with o3: prefix format

### DIFF
--- a/packages/esm-billing-app/translations/en.json
+++ b/packages/esm-billing-app/translations/en.json
@@ -265,6 +265,7 @@
   "selectitemstobeclaimed": "Select items that are to be included in the claims",
   "selectPaymentMethod": "Select payment method",
   "selectPaymentMode": "Select payment mode",
+  "selectProvider": "Select Provider",
   "selectTimesheet": "Select timesheet",
   "sendClaim": "Pre authorization request sent successfully",
   "sendClaimError": "Pre authorization request failed, please try later",

--- a/packages/esm-morgue-app/src/card/avail-compartment.compartment.tsx
+++ b/packages/esm-morgue-app/src/card/avail-compartment.compartment.tsx
@@ -1,6 +1,6 @@
 import { Tag } from '@carbon/react';
 import { View } from '@carbon/react/icons';
-import { ConfigurableLink, useVisit } from '@openmrs/esm-framework';
+import { ConfigurableLink, useVisit, UserHasAccess } from '@openmrs/esm-framework';
 import capitalize from 'lodash-es/capitalize';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -69,11 +69,13 @@ const AvailableCompartment: React.FC<AvailableCompartmentProps> = ({ patientInfo
           )}
         </span>
         <span className={styles.viewDetails}>
-          <ConfigurableLink
-            className={styles.viewDetailsLink}
-            to={`\${openmrsSpaBase}/patient/${patientUuid}/chart/deceased-panel`}>
-            <View size={20} />
-          </ConfigurableLink>
+          <UserHasAccess privilege="o3 : View Mortuary Records">
+            <ConfigurableLink
+              className={styles.viewDetailsLink}
+              to={`\${openmrsSpaBase}/patient/${patientUuid}/chart/deceased-panel`}>
+              <View size={20} />
+            </ConfigurableLink>
+          </UserHasAccess>
         </span>
       </div>
       <div className={styles.borderLine}></div>

--- a/packages/esm-morgue-app/src/extension/actionButton.component.tsx
+++ b/packages/esm-morgue-app/src/extension/actionButton.component.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { launchWorkspace, navigate } from '@openmrs/esm-framework';
+import { launchWorkspace, navigate, UserHasAccess } from '@openmrs/esm-framework';
 import { Movement, Return, ShareKnowledge } from '@carbon/react/icons';
 import React from 'react';
 import { useAdmissionLocation } from '../hook/useMortuaryAdmissionLocation';
@@ -50,21 +50,33 @@ const ActionButton: React.FC<ActionButtonProps> = ({ patientUuid }) => {
 
   return (
     <div className={styles.actionButton}>
-      <Button kind="primary" size="sm" renderIcon={Return} onClick={handleNavigateToAllocationPage}>
-        {t('allocation', 'Allocation View')}
-      </Button>
+      <UserHasAccess privilege="o3 : View Mortuary Dashboard">
+        <Button kind="primary" size="sm" renderIcon={Return} onClick={handleNavigateToAllocationPage}>
+          {t('allocation', 'Allocation View')}
+        </Button>
+      </UserHasAccess>
+
       {isPatientInAdmissionLocation && (
         <>
-          <Button
-            kind="secondary"
-            size="sm"
-            renderIcon={ShareKnowledge}
-            onClick={() => handleSwapForm(patientUuid, bedId)}>
-            {t('swapCompartment', 'Swap compartment')}
-          </Button>
-          <Button kind="danger" size="sm" renderIcon={Movement} onClick={() => handleDischargeForm(patientUuid, bedId)}>
-            {t('discharge', 'Discharge body')}
-          </Button>
+          <UserHasAccess privilege="o3: Swap Mortuary Compartments">
+            <Button
+              kind="secondary"
+              size="sm"
+              renderIcon={ShareKnowledge}
+              onClick={() => handleSwapForm(patientUuid, bedId)}>
+              {t('swapCompartment', 'Swap compartment')}
+            </Button>
+          </UserHasAccess>
+
+          <UserHasAccess privilege="o3: Discharge Body from Mortuary">
+            <Button
+              kind="danger"
+              size="sm"
+              renderIcon={Movement}
+              onClick={() => handleDischargeForm(patientUuid, bedId)}>
+              {t('discharge', 'Discharge body')}
+            </Button>
+          </UserHasAccess>
         </>
       )}
     </div>

--- a/packages/esm-morgue-app/src/root.component.tsx
+++ b/packages/esm-morgue-app/src/root.component.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { UserHasAccess } from '@openmrs/esm-framework';
 import MainComponent from './component/main.component';
 import { AdmittedQueue } from './tables/admitted-queue.component';
 
@@ -8,10 +9,12 @@ const Root: React.FC = () => {
 
   return (
     <BrowserRouter basename={baseName}>
-      <Routes>
-        <Route path="/" element={<MainComponent />} />
-        <Route path="/allocation" element={<AdmittedQueue />} />
-      </Routes>
+      <UserHasAccess privilege="o3 : View Mortuary Dashboard">
+        <Routes>
+          <Route path="/" element={<MainComponent />} />
+          <Route path="/allocation" element={<AdmittedQueue />} />
+        </Routes>
+      </UserHasAccess>
     </BrowserRouter>
   );
 };

--- a/packages/esm-morgue-app/src/routes.json
+++ b/packages/esm-morgue-app/src/routes.json
@@ -13,7 +13,10 @@
       "meta": {
         "name": "morgue",
         "title": "morgue",
-        "slot": "morgue-dashboard-slot"
+        "slot": "morgue-dashboard-slot",
+        "privileges": [
+          "o3 : View Mortuary Dashboard"
+        ]
       }
     },
     {
@@ -21,7 +24,19 @@
       "component": "actionBarButtons",
       "slot": "mortuary-action-buttons-slot",
       "meta": {
-        "fullWidth": false
+        "fullWidth": false,
+        "privileges": [
+          "o3 : View Mortuary Dashboard",
+          "o3 : Admit Body to Mortuary",
+          "o3 : Edit Mortuary Records",
+          "o3 : Discharge Body from Mortuary",
+          "o3 : View Mortuary Compartments",
+          "o3 : Swap Mortuary Compartments",
+          "o3 : View Mortuary Billing",
+          "o3 : Process Mortuary Payments",
+          "o3 : View Mortuary Reports",
+          "o3 : Generate Mortuary Reports"
+        ]
       }
     },
     {
@@ -35,10 +50,15 @@
     {
       "component": "root",
       "name": "morgue-dashboard-root",
-      "slot": "morgue-dashboard-slot"
+      "slot": "morgue-dashboard-slot",
+      "meta": {
+        "privileges": [
+          "o3 : View Mortuary Dashboard"
+        ]
+      }
     }
   ],
-   "workspaces": [
+  "workspaces": [
     {
       "name": "patient-additional-info-form",
       "component": "patientAdditionalInfoForm",

--- a/packages/esm-morgue-app/src/tables/admitted-queue.component.tsx
+++ b/packages/esm-morgue-app/src/tables/admitted-queue.component.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { UserHasAccess } from '@openmrs/esm-framework';
 import DeceasedFilter from '../header/admitted-queue-header.component';
 import styles from './admitted-queue.scss';
 import CompartmentView from '../card/compartment-view.compartment';
@@ -41,7 +42,9 @@ export const AdmittedQueue: React.FC = () => {
             subTitle={t('noAdmittedBodies', 'There are no admitted bodies matching your search')}
           />
         ) : (
-          <CompartmentView />
+          <UserHasAccess privilege="o3 : View Mortuary Compartments">
+            <CompartmentView />
+          </UserHasAccess>
         )}
       </div>
     </div>

--- a/packages/esm-morgue-app/src/tabs/tabs.component.tsx
+++ b/packages/esm-morgue-app/src/tabs/tabs.component.tsx
@@ -1,6 +1,6 @@
 import { Button, Layer, Tab, TabList, TabPanel, TabPanels, Tabs } from '@carbon/react';
 import { SearchAdvanced } from '@carbon/react/icons';
-import { launchWorkspace } from '@openmrs/esm-framework';
+import { launchWorkspace, UserHasAccess } from '@openmrs/esm-framework';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import useEmrConfiguration from '../hook/useAdmitPatient';
@@ -56,14 +56,16 @@ export const MorgueTabs: React.FC = () => {
             ))}
           </TabList>
           <div className={styles.actionBtn}>
-            <Button
-              kind="primary"
-              renderIcon={(props) => <SearchAdvanced size={40} {...props} />}
-              onClick={() => handleAdmitBodyWorkspace()}
-              className={styles.actionBtn}
-              disabled={isLoadingDischargedPatient}>
-              {t('admitBodies', 'Admit bodies')}
-            </Button>
+            <UserHasAccess privilege="o3 : Admit Body to Mortuary">
+              <Button
+                kind="primary"
+                renderIcon={(props) => <SearchAdvanced size={40} {...props} />}
+                onClick={() => handleAdmitBodyWorkspace()}
+                className={styles.actionBtn}
+                disabled={isLoadingDischargedPatient}>
+                {t('admitBodies', 'Admit bodies')}
+              </Button>
+            </UserHasAccess>
           </div>
         </div>
 


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Initial setup of mortuary module privileges using the correct o3: prefix format.
This implementation ensures proper access control for the mortuary module features.

Changes include:
- Added "o3: View Mortuary Dashboard" for accessing the mortuary dashboard
- Added "o3: Swap Mortuary Compartments" for compartment swapping functionality
- Added "o3: Discharge Body from Mortuary" for body discharge operations


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
