### PR TITLE
(fix): Fix response uuid

### DIFF
--- a/packages/esm-billing-app/src/claims/claims-management/table/claim-table.component.tsx
+++ b/packages/esm-billing-app/src/claims/claims-management/table/claim-table.component.tsx
@@ -92,6 +92,9 @@ const ClaimsTable: React.FC<TableProps> = ({ title, emptyStateText, emptyStateHe
   const layout = useLayoutType();
   const size = layout === 'tablet' ? 'lg' : 'md';
   const filteredClaimIds = filteredClaims.map((claim) => claim.responseUUID);
+  const responseUUIDs = filteredClaimIds
+    .map((claimId) => claims.find((c) => c.responseUUID === claimId)?.responseUUID)
+    .filter((uuid) => uuid);
 
   const getHeaders = (): Header[] => {
     let baseHeaders = [
@@ -208,7 +211,7 @@ const ClaimsTable: React.FC<TableProps> = ({ title, emptyStateText, emptyStateHe
           filters={filters}
           onFilterChanged={setFilters}
           statusOptions={status}
-          filteredClaimIds={filteredClaimIds}
+          filteredClaimIds={responseUUIDs}
         />
       </div>
       <DataTable rows={results} headers={headers} isSortable useZebraStyles>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
### What does this PR do?
* Gray out the update all button when the response UUID is null / not available. 

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

![Screenshot from 2025-05-12 11-08-11](https://github.com/user-attachments/assets/b81b4123-e289-41b1-a0eb-1c175a12f76a)


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
