### PR TITLE
chore: remove unused billinng component route config hindering home page rendering

### DIFF
--- a/packages/esm-billing-app/src/routes.json
+++ b/packages/esm-billing-app/src/routes.json
@@ -17,14 +17,6 @@
   ],
   "extensions": [
     {
-      "component": "billingDashboardLink",
-      "name": "billing-dashboard-link",
-      "slot": "homepage-dashboard-slot",
-      "meta": {
-        "slot": "billing-dashboard-slot"
-      }
-    },
-    {
       "component": "benefitsPackageDashboardLink",
       "name": "benefits-package-dashboard-link",
       "slot": "patient-chart-dashboard-slot",


### PR DESCRIPTION


## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
 - Clean up unused billing route config hindering loading of home page as a result of conflicting meta.name(route/path), when unspecified defaults home pages's relative path ("/" or "")

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
