### PR TITLE
(feat): Add use-type filtering to Claims Table component

### DIFF
--- a/packages/esm-billing-app/src/claims/claims-management/table/claim-table.component.tsx
+++ b/packages/esm-billing-app/src/claims/claims-management/table/claim-table.component.tsx
@@ -39,7 +39,13 @@ const ClaimStatus = ({ row }: { row: DataTableRow }) => {
   );
 };
 
-const ClaimsTable: React.FC<TableProps> = ({ title, emptyStateText, emptyStateHeader, includeClaimCode = false }) => {
+const ClaimsTable: React.FC<TableProps> = ({
+  title,
+  emptyStateText,
+  emptyStateHeader,
+  includeClaimCode = false,
+  use = 'claim',
+}) => {
   const { claims, isLoading } = useFacilityClaims();
   const { t } = useTranslation();
   const [filters, setFilters] = useState<ClaimsPreAuthFilter>({
@@ -60,6 +66,10 @@ const ClaimsTable: React.FC<TableProps> = ({ title, emptyStateText, emptyStateHe
   );
 
   const [pageSize, setPageSize] = useState(5);
+
+  const claimsByUse = useMemo(() => {
+    return claims.filter((claim) => claim.use === use);
+  }, [claims, use]);
 
   const filterClaims = (claim: Claim) => {
     const status = filters?.status;
@@ -85,15 +95,15 @@ const ClaimsTable: React.FC<TableProps> = ({ title, emptyStateText, emptyStateHe
     return statusMatch && searchMatch && dateMatch;
   };
 
-  const filteredClaims = claims.filter(filterClaims);
+  const filteredClaims = claimsByUse.filter(filterClaims);
   const { paginated, goTo, results, currentPage } = usePagination(filteredClaims, pageSize);
-  const { pageSizes } = usePaginationInfo(pageSize, claims.length, currentPage, results.length);
+  const { pageSizes } = usePaginationInfo(pageSize, claimsByUse.length, currentPage, results.length);
   const responsiveSize = isDesktop(useLayoutType()) ? 'sm' : 'lg';
   const layout = useLayoutType();
   const size = layout === 'tablet' ? 'lg' : 'md';
   const filteredClaimIds = filteredClaims.map((claim) => claim.responseUUID);
   const responseUUIDs = filteredClaimIds
-    .map((claimId) => claims.find((c) => c.responseUUID === claimId)?.responseUUID)
+    .map((claimId) => claimsByUse.find((c) => c.responseUUID === claimId)?.responseUUID)
     .filter((uuid) => uuid);
 
   const getHeaders = (): Header[] => {
@@ -131,7 +141,7 @@ const ClaimsTable: React.FC<TableProps> = ({ title, emptyStateText, emptyStateHe
     );
   }
 
-  if (claims.length === 0) {
+  if (claimsByUse.length === 0) {
     return (
       <div className={styles.claimsTable}>
         <EmptyState displayText={t(emptyStateText)} headerTitle={t(emptyStateHeader)} />

--- a/packages/esm-billing-app/src/claims/claims-management/table/claims-list-table.component.tsx
+++ b/packages/esm-billing-app/src/claims/claims-management/table/claims-list-table.component.tsx
@@ -259,6 +259,7 @@ const ClaimsManagementTable: React.FC = () => {
       emptyStateText="emptyClaimsState"
       emptyStateHeader="emptyClaimsHeader"
       includeClaimCode={true}
+      use="claim"
     />
   );
 };

--- a/packages/esm-billing-app/src/claims/claims-management/table/preauth-table.tmp.component.tsx
+++ b/packages/esm-billing-app/src/claims/claims-management/table/preauth-table.tmp.component.tsx
@@ -8,6 +8,7 @@ const PreauthTableTemporary: React.FC = () => {
       emptyStateText="emptyPreauthState"
       emptyStateHeader="emptyPreauthHeader"
       includeClaimCode={false}
+      use="preauthorization"
     />
   );
 };

--- a/packages/esm-billing-app/src/claims/claims-management/table/use-facility-claims.ts
+++ b/packages/esm-billing-app/src/claims/claims-management/table/use-facility-claims.ts
@@ -4,7 +4,7 @@ import { FacilityClaim } from '../../../types';
 
 export const useFacilityClaims = () => {
   const customPresentation =
-    'custom:(uuid,claimCode,dateFrom,dateTo,claimedTotal,approvedTotal,status,externalId,responseUUID,provider:(display),patient:(display))';
+    'custom:(uuid,claimCode,use,dateFrom,dateTo,claimedTotal,approvedTotal,status,externalId,responseUUID,provider:(display),patient:(display))';
   const url = `${restBaseUrl}/claim?v=${customPresentation}`;
 
   const { data, error, isLoading, mutate, isValidating } = useSWR<FetchResponse<{ results: Array<FacilityClaim> }>>(

--- a/packages/esm-billing-app/src/types/index.ts
+++ b/packages/esm-billing-app/src/types/index.ts
@@ -539,6 +539,7 @@ export interface shifIdentifiersResponse {
 export type FacilityClaim = {
   uuid: string;
   claimCode: string;
+  use: string;
   dateFrom: string;
   dateTo: string;
   claimedTotal: number;
@@ -606,6 +607,7 @@ export interface TableProps {
   emptyStateText: string;
   emptyStateHeader: string;
   includeClaimCode?: boolean;
+  use?: string;
 }
 
 export interface ProgressTracker {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
### What does this PR do?
- Implements filtering by `use` type in ClaimsTable component to properly separate claims from preauthorization records.
- Fixes the issue where claims and preauthorization records were mixed in the same table.

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
[Screencast from 10-06-2025 09:48:05 ALASIRI.webm](https://github.com/user-attachments/assets/7532eeb5-dab0-47c1-b171-33d12290f2d7)



*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
