### PR TITLE
fix : resolve error while Adjusting bill line items having payments

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "yarn test --coverage",
     "postinstall": "husky install",
     "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx,css,scss}\" \"e2e/**/*.ts\"",
-    "start": " openmrs develop",
+    "start": "openmrs develop",
     "verify": "turbo run lint && turbo run typescript",
     "preinstall": "npx only-allow yarn"
   },

--- a/packages/esm-billing-app/__mocks__/bill.mock.ts
+++ b/packages/esm-billing-app/__mocks__/bill.mock.ts
@@ -1,4 +1,4 @@
-import { MappedBill } from '../src/types';
+import { MappedBill, PaymentStatus } from '../src/types';
 
 export const mockBillData: Array<MappedBill> = [
   {
@@ -7,7 +7,7 @@ export const mockBillData: Array<MappedBill> = [
     patientName: 'John Doe',
     identifier: 'TEST123',
     patientUuid: 'patient-uuid-1',
-    status: 'PENDING',
+    status: PaymentStatus.PENDING,
     receiptNumber: '1000-1',
     cashier: {
       uuid: 'cashier-uuid-1',
@@ -74,7 +74,11 @@ export const mockCurrentBillableService = {
   uuid: 'service-uuid-1',
   name: 'TEST SERVICE',
   shortName: 'TEST SERVICE',
-  serviceStatus: 'ENABLED',
+  serviceStatus: 'ENABLED' as const,
+  stockItem: {
+    uuid: 'stock-item-uuid-1',
+    display: 'Test Stock Item',
+  },
   serviceType: {
     uuid: 'servicetype-uuid-1',
     display: 'Test Service',

--- a/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill/edit-bill-util.ts
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/edit-bill/edit-bill-util.ts
@@ -43,7 +43,15 @@ export const createEditBillPayload = (lineItem, data, bill, adjustmentReason: st
     cashPoint: bill.cashPointUuid,
     cashier: bill.cashier.uuid,
     lineItems: bill.lineItems.map((li) => formatLineItem(li.uuid === lineItem.uuid ? updatedLineItem : li)),
-    payments: bill.payments,
+    payments: bill.payments.map((payment) => ({
+      amount: payment.amount,
+      amountTendered: payment.amountTendered,
+      attributes: payment.attributes.map((attribute) => ({
+        attributeType: attribute.attributeType?.uuid,
+        value: attribute.value,
+      })),
+      instanceType: payment.instanceType.uuid,
+    })),
     patient: bill.patientUuid,
     status: bill.status,
     billAdjusted: bill.uuid,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Bill line item adjustments were failing due to improper handling of payment instance type parameters.
Solution. This PR Corrected the method for passing payment instance type data


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
