### PR TITLE
fix: add left panel link missing for etls page

### DIFF
--- a/packages/esm-admin-app/src/routes.json
+++ b/packages/esm-admin-app/src/routes.json
@@ -15,6 +15,11 @@
       "slot": "admin-left-panel-slot"
     }, 
     {
+      "component": "etlAdministrationLeftPannelLink",
+      "name": "etl-administration-left-panel-link",
+      "slot": "admin-left-panel-slot"
+    },
+    {
       "component": "locationsLeftPanelLink",
       "name": "locations-left-panel-link",
       "slot": "admin-left-panel-slot"


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
