### PR TITLE
fix(billing): improve billable item lookup for drug orders

### DIFF
--- a/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/create-bill/create-bill.workspace.tsx
+++ b/packages/esm-billing-app/src/billable-services/bill-manager/workspaces/create-bill/create-bill.workspace.tsx
@@ -156,7 +156,8 @@ const CreateBillWorkspace: React.FC<CreateBillWorkspaceProps> = ({
   const defaultPaymentStatus = 'PENDING';
   const isTablet = useLayoutType() === 'tablet';
   const { cashPointUuid, cashierUuid } = useConfig<BillingConfig>();
-  const { billableItem, isLoading } = useBillableItem(order?.concept?.uuid ?? order?.drug?.concept?.uuid);
+  const drugUuid = order?.drug?.uuid;
+  const { billableItem, isLoading } = useBillableItem(order?.concept?.uuid ?? order?.drug?.concept?.uuid, drugUuid);
 
   const comboBoxItems =
     billableItem?.servicePrices?.map((item) => ({


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR fixes an issue with how we generate bills for drug items

- Add drugUuid parameter to useBillableItem hook
- Modify API call to include drug UUID when available
- Use first result for drug-specific lookups, fallback to concept UUID matching
- Fixes issue where wrong stock items were being billed for drug orders



## Screenshots
https://github.com/user-attachments/assets/0a17ea2d-efb5-4158-b853-d9532f74c75f


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
