### PR TITLE
fix : resolve price information to show correct price on drug order

### DIFF
--- a/packages/esm-billing-app/src/billable-services/billiable-item/drug-order/drug-order.component.tsx
+++ b/packages/esm-billing-app/src/billable-services/billiable-item/drug-order/drug-order.component.tsx
@@ -24,7 +24,7 @@ type DrugOrderProps = {
 const DrugOrder: React.FC<DrugOrderProps> = ({ order }) => {
   const { t } = useTranslation();
   const { stockItem, isLoading: isLoadingInventory } = useSockItemInventory(order?.drug?.uuid);
-  const { billableItem, isLoading } = useBillableItem(order?.drug.concept.uuid);
+  const { billableItem, isLoading } = useBillableItem(order?.drug.concept.uuid, order?.drug.uuid);
   if (isLoading || isLoadingInventory) {
     return null;
   }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
This PR uses drugUuid to fetch price information for drugs. This should resolve error in displaying the wrong pricing information cc @andrineM @enyaencha 


## Screenshots
https://github.com/user-attachments/assets/d61a06f4-971e-4599-b3ea-24fdb47b16d8



## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
