### PR TITLE
restore lab manifest links in diagnostics nav group

### DIFF
--- a/packages/esm-lab-manifest-app/src/index.ts
+++ b/packages/esm-lab-manifest-app/src/index.ts
@@ -59,14 +59,14 @@ export const requeueLabManifestConfirmModal = getAsyncLifecycle(
 export const manifestOverviewDashboardLink = getSyncLifecycle(
   createLeftPanelLink({
     name: 'lab-manifest/overview',
-    title: 'Overview',
+    title: 'Manifest overview',
   }),
   options,
 );
 export const manifestsDashboardLink = getSyncLifecycle(
   createLeftPanelLink({
     name: 'lab-manifest',
-    title: 'Manifests',
+    title: 'Lab manifests',
   }),
   options,
 );

--- a/packages/esm-lab-manifest-app/src/routes.json
+++ b/packages/esm-lab-manifest-app/src/routes.json
@@ -26,12 +26,14 @@
     {
       "component": "manifestOverviewDashboardLink",
       "name": "manifest-overview-link",
-      "slot": "lab-manifest-dashbaord-link-slot"
+      "order": 1,
+      "slot": "diagnostics-group-nav-slot"
     },
     {
       "component": "manifestsDashboardLink",
       "name": "manifests-dashboard-link",
-      "slot": "lab-manifest-dashbaord-link-slot"
+      "order": 2,
+      "slot": "diagnostics-group-nav-slot"
     },
     {
       "name": "lab-manifest-form",


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Restore lab manifest overview and listings on diagnostics

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
[Screencast from 2025-08-14 23-53-32.webm](https://github.com/user-attachments/assets/a1295493-a378-4e75-8410-47beb9eef1b9)

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
