### PR TITLE
Add support documents to claims form thouh has bug with interventions

### DIFF
--- a/packages/esm-billing-app/src/claims/dashboard/form/claims-form.component.tsx
+++ b/packages/esm-billing-app/src/claims/dashboard/form/claims-form.component.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   ButtonSet,
   Column,
+  ComboBox,
   Form,
   InlineLoading,
   InlineNotification,
@@ -11,11 +12,10 @@ import {
   Stack,
   TextInput,
   TextInputSkeleton,
-  ComboBox,
 } from '@carbon/react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { navigate, showModal, showSnackbar, toOmrsIsoString, useConfig, useSession } from '@openmrs/esm-framework';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -25,47 +25,22 @@ import { BillingConfig } from '../../../config-schema';
 import { useSystemSetting } from '../../../hooks/getMflCode';
 import usePatientDiagnosis from '../../../hooks/usePatientDiagnosis';
 import useProvider from '../../../hooks/useProvider';
+import useProviderList from '../../../hooks/useProviderList';
 import { ClaimSummary, LineItem, MappedBill, OTPVerificationModalOptions } from '../../../types';
 import ClaimExplanationAndJusificationInput from './claims-explanation-and-justification-form-input.component';
-import { processClaims, SHAPackagesAndInterventionVisitAttribute, useVisit } from './claims-form.resource';
-import useProviderList from '../../../hooks/useProviderList';
+import { ClaimsFormSchema, ClaimsFormSchemaBase, processClaims, useVisit } from './claims-form.resource';
 
-import styles from './claims-form.scss';
 import debounce from 'lodash-es/debounce';
-import { formatDateTime } from '../../utils';
 import { otpManager } from '../../../hooks/useOTP';
 import { usePhoneNumberAttribute } from '../../../hooks/usePhoneNumber';
+import { formatDateTime } from '../../utils';
+import styles from './claims-form.scss';
+import ClaimsSupportingDocumentsInput from './claims-supporting-documents-inputs.form';
 
 type ClaimsFormProps = {
   bill: MappedBill;
   selectedLineItems: LineItem[];
 };
-
-const ClaimsFormSchemaBase = z.object({
-  claimExplanation: z.string(),
-  claimJustification: z.string(),
-  diagnoses: z.array(z.string()),
-  visitType: z.string(),
-  facility: z.string(),
-  treatmentStart: z.string(),
-  treatmentEnd: z.string(),
-  packages: z.array(z.string()),
-  interventions: z.array(z.string()),
-  provider: z.string(),
-});
-
-const ClaimsFormSchema = z.object({
-  claimExplanation: z.string().min(1, { message: 'Claim explanation is required' }),
-  claimJustification: z.string().min(1, { message: 'Claim justification is required' }),
-  diagnoses: z.array(z.string()).min(1, { message: 'At least one diagnosis is required' }),
-  visitType: z.string().min(1, { message: 'Visit type is required' }),
-  facility: z.string().min(1, { message: 'Facility is required' }),
-  treatmentStart: z.string().min(1, { message: 'Treatment start date is required' }),
-  treatmentEnd: z.string().min(1, { message: 'Treatment end date is required' }),
-  packages: z.array(z.string()).min(1, { message: 'At least one package is required' }),
-  interventions: z.array(z.string()).min(1, { message: 'At least one intervention is required' }),
-  provider: z.string().min(1, { message: 'Provider is required' }),
-});
 
 enum OTPState {
   NOT_STARTED = 'not_started',
@@ -302,6 +277,7 @@ const ClaimsForm: React.FC<ClaimsFormProps> = ({ bill, selectedLineItems }) => {
       billNumber: billUuid,
       packages: data.packages,
       interventions: data.interventions,
+      supportingDocuments: data.supportingDocuments ?? [],
     };
 
     try {
@@ -640,7 +616,7 @@ const ClaimsForm: React.FC<ClaimsFormProps> = ({ bill, selectedLineItems }) => {
             validationEnabled={validationEnabled}
             onInteraction={() => setValidationEnabled(true)}
           />
-
+          <ClaimsSupportingDocumentsInput />
           <ButtonSet className={styles.buttonSet}>
             <Button className={styles.button} kind="secondary" onClick={handleDiscardClaim}>
               {t('discardClaim', 'Discard Claim')}

--- a/packages/esm-billing-app/src/claims/dashboard/form/claims-form.resource.ts
+++ b/packages/esm-billing-app/src/claims/dashboard/form/claims-form.resource.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import useSWR from 'swr';
 import useSWRImmutable from 'swr/immutable';
 import { mockInterventions, mockPackages } from './claims-form.mocks';
+import z from 'zod';
 
 interface Provider {
   uuid: string;
@@ -97,3 +98,65 @@ export const updateClaimStatus = (responseUUID: string) => {
     method: 'GET',
   });
 };
+
+export const ClaimsFormSchemaBase = z.object({
+  claimExplanation: z.string(),
+  claimJustification: z.string(),
+  diagnoses: z.array(z.string()),
+  visitType: z.string(),
+  facility: z.string(),
+  treatmentStart: z.string(),
+  treatmentEnd: z.string(),
+  packages: z.array(z.string()),
+  interventions: z.array(z.string()),
+  provider: z.string(),
+});
+
+export const ClaimsFormSchema = z.object({
+  claimExplanation: z.string().min(1, { message: 'Claim explanation is required' }),
+  claimJustification: z.string().min(1, { message: 'Claim justification is required' }),
+  diagnoses: z.array(z.string()).min(1, { message: 'At least one diagnosis is required' }),
+  visitType: z.string().min(1, { message: 'Visit type is required' }),
+  facility: z.string().min(1, { message: 'Facility is required' }),
+  treatmentStart: z.string().min(1, { message: 'Treatment start date is required' }),
+  treatmentEnd: z.string().min(1, { message: 'Treatment end date is required' }),
+  packages: z.array(z.string()).min(1, { message: 'At least one package is required' }),
+  interventions: z.array(z.string()).min(1, { message: 'At least one intervention is required' }),
+  provider: z.string().min(1, { message: 'Provider is required' }),
+  supportingDocuments: z
+    .object({
+      name: z.string(),
+      type: z.string(),
+      size: z.number(),
+      base64: z.string(),
+      intervention: z.string(),
+      purpose: z.enum([
+        'CLAIM_FORM',
+        'PREAUTH_FORM',
+        'DISCHARGE_SUMMARY',
+        'PRESCRIPTION',
+        'LAB_ORDER',
+        'INVOICE',
+        'BIO_DETAILS',
+        'IMAGING_ORDER',
+        'OTHER',
+        'FINAL_BILL',
+        'LAB_RESULTS',
+        'DEATH_NOTICE',
+        'THEATRE_NOTES',
+        'BIRTH_NOTIFICATION',
+      ]),
+      uploadedAt: z.date({ coerce: true }),
+    })
+    .array(),
+});
+
+
+export function fileToBase64(file:File) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = (error) => reject(error);
+  });
+}

--- a/packages/esm-billing-app/src/claims/dashboard/form/claims-form.scss
+++ b/packages/esm-billing-app/src/claims/dashboard/form/claims-form.scss
@@ -153,3 +153,9 @@
   padding: layout.$spacing-05;
   gap: layout.$spacing-05;
 }
+.doc{
+  border: 1px solid colors.$gray-40;
+  padding: layout.$spacing-03;
+  margin: layout.$spacing-03 0 layout.$spacing-03 0;
+  position: relative;
+}

--- a/packages/esm-billing-app/src/claims/dashboard/form/claims-supporting-documents-inputs.form.tsx
+++ b/packages/esm-billing-app/src/claims/dashboard/form/claims-supporting-documents-inputs.form.tsx
@@ -1,0 +1,149 @@
+import { Button, Dropdown, FileUploader, Tag } from '@carbon/react';
+import React from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import z, { isValid } from 'zod';
+import { ClaimsFormSchema, fileToBase64 } from './claims-form.resource';
+import { showSnackbar } from '@openmrs/esm-framework';
+import styles from './claims-form.scss';
+import { TrashCan } from '@carbon/react/icons';
+const ClaimsSupportingDocumentsInput = () => {
+  const { t } = useTranslation();
+  const form = useForm<z.infer<typeof ClaimsFormSchema>>();
+  const supportDocs = form.watch('supportingDocuments') ?? [];
+  const selectedInterventionsObservable = form.watch('interventions') ?? [];
+
+  return (
+    <div>
+      {supportDocs?.map((doc, i) => (
+        <div key={i} className={styles.doc}>
+          <Button
+            hasIconOnly
+            renderIcon={TrashCan}
+            kind="danger--ghost"
+            onClick={() =>
+              form.setValue(
+                'supportingDocuments',
+                supportDocs.filter((_, ind) => ind != i),
+              )
+            }
+          />
+          <Controller
+            control={form.control}
+            name={`supportingDocuments.${i}.base64`}
+            render={({ field, fieldState }) => (
+              <div className="cds--file__container">
+                <FileUploader
+                  accept={['.jpg', '.png']}
+                  buttonKind="tertiary"
+                  buttonLabel={t('select', 'Select')}
+                  filenameStatus="edit"
+                  labelDescription={t(
+                    'supportDocsInstruction',
+                    'Max file size is 1 MB. Only .jpg and .png files are supported.',
+                  )}
+                  labelTitle={t('uploadSupportFiles', 'Upload support files')}
+                  name=""
+                  onChange={async ({
+                    target: {
+                      files: [file],
+                    },
+                  }) => {
+                    if (file instanceof File) {
+                      const oneMBInBytes = 1024 * 1024; // 1MB = 1024 KB * 1024 B/KB
+                      if (file.size > oneMBInBytes) {
+                        showSnackbar({
+                          title: t('error', 'Error'),
+                          kind: 'error',
+                          subtitle: t('fileToLargeError', 'File size to large exceeding 1MB'),
+                        });
+                        return;
+                      }
+                      const base64 = await fileToBase64(file);
+                      field.onChange(base64);
+                      form.setValue(`supportingDocuments.${i}.size`, file.size);
+                      form.setValue(`supportingDocuments.${i}.name`, file.name);
+                      form.setValue(`supportingDocuments.${i}.type`, file.type);
+                      form.setValue(`supportingDocuments.${i}.uploadedAt`, new Date());
+                    }
+                  }}
+                  onClick={() => {}}
+                  onDelete={() => {
+                    form.setValue(
+                      'supportingDocuments',
+                      supportDocs.filter((_, ind) => ind != i),
+                    );
+                  }}
+                  size="md"
+                />
+                {doc.size && <Tag>{(doc.size / 1024).toFixed(2)} KB</Tag>}
+              </div>
+            )}
+          />
+          <Controller
+            control={form.control}
+            name={`supportingDocuments.${i}.intervention`}
+            render={({ field, fieldState }) => (
+              <Dropdown
+                {...field}
+                invalid={Boolean(fieldState?.error?.message)}
+                invalidText={fieldState?.error?.message}
+                id={'document-intervention'}
+                selectedItem={field.value}
+                onChange={({ selectedItem }) => field.onChange(selectedItem)}
+                items={selectedInterventionsObservable}
+                itemToString={(item) => item}
+                label={t('intervention', 'Intervention')}
+                titleText={t('intervention', 'Intervention')}
+              />
+            )}
+          />
+          <Controller
+            control={form.control}
+            name={`supportingDocuments.${i}.purpose`}
+            render={({ field, fieldState }) => (
+              <Dropdown
+                invalid={Boolean(fieldState?.error?.message)}
+                invalidText={fieldState?.error?.message}
+                id={'document-purpose'}
+                {...field}
+                selectedItem={field.value}
+                onChange={({ selectedItem }) => field.onChange(selectedItem)}
+                items={[
+                  'CLAIM_FORM',
+                  'PREAUTH_FORM',
+                  'DISCHARGE_SUMMARY',
+                  'PRESCRIPTION',
+                  'LAB_ORDER',
+                  'INVOICE',
+                  'BIO_DETAILS',
+                  'IMAGING_ORDER',
+                  'OTHER',
+                  'FINAL_BILL',
+                  'LAB_RESULTS',
+                  'DEATH_NOTICE',
+                  'THEATRE_NOTES',
+                  'BIRTH_NOTIFICATION',
+                ]}
+                label={t('purpose', 'Purpose')}
+                titleText={t('purpose', 'Purpose')}
+                itemToString={(item) => item.toLowerCase().replace('_', ' ')}
+              />
+            )}
+          />
+        </div>
+      ))}
+      <Button
+        disabled={supportDocs.length >= 4}
+        kind="tertiary"
+        onClick={async () => {
+          const valid = await form.trigger(`supportingDocuments`);
+          if (!supportDocs?.length || valid) form.setValue('supportingDocuments', [...supportDocs, {}]);
+        }}>
+        {t('addSupportDocs', 'Add support docs')}
+      </Button>
+    </div>
+  );
+};
+
+export default ClaimsSupportingDocumentsInput;


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

- Advance claims form to support support documents

__NB:Has a bug on intervensions field on support document section, not showing the selected interventions despite being watched from form state__

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots


https://github.com/user-attachments/assets/4b28ff1c-ddc2-4807-b2fb-a6b9f955d80e



*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
